### PR TITLE
Simplify New Relic setup

### DIFF
--- a/lib/travis/hub/monitoring.rb
+++ b/lib/travis/hub/monitoring.rb
@@ -5,13 +5,23 @@ module Travis
   class Hub
     module Monitoring
       def self.start
-        puts "Starting New Relic with env: #{Travis.config.env}"
+        puts "Starting New Relic with env: #{Travis.env}"
 
         # Add controller instrumentation to the AMQP message handlers
+        Travis::Hub::Handler::Configure.class_eval do
+          include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+          add_transaction_tracer(:handle)
+        end
+
         Travis::Hub::Handler::Job.class_eval do
           include NewRelic::Agent::Instrumentation::ControllerInstrumentation
           add_transaction_tracer(:handle_log_update)
           add_transaction_tracer(:handle_update)
+        end
+
+        Travis::Hub::Handler::Request.class_eval do
+          include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+          add_transaction_tracer(:handle)
         end
 
         Travis::Hub::Handler::Worker.class_eval do


### PR DESCRIPTION
As you can see we had to do some crazy shit to get NR working, well, it seems it was because of our gemfile requiring in the rails engine we had in Travis core.

well, all fixed now, and added some monitoring for Request and Configure handlers.
