### PR TITLE
Extract logging to travis-logs

### DIFF
--- a/lib/travis/hub/handler/job.rb
+++ b/lib/travis/hub/handler/job.rb
@@ -28,7 +28,9 @@ module Travis
           new_relic :update
 
           def log
-            ::Job::Test.append_log!(payload['id'], payload['log'])
+            # TODO hot compat, remove once workers publish to "reporting.jobs.logs" directly
+            publisher = Travis::Amqp::Publisher.jobs('logs')
+            publisher.publish(:data => payload, :uuid => Travis.uuid)
           end
           instrument :log
           new_relic :log

--- a/spec/travis/hub/handler/job_spec.rb
+++ b/spec/travis/hub/handler/job_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe Travis::Hub::Handler::Job do
-  let(:job)     { stub('job', :update_attributes => nil) }
-  let(:payload) { {} }
-  let(:handler) { Travis::Hub::Handler::Job.new(nil, payload) }
+  let(:job)       { stub('job', :update_attributes => nil) }
+  let(:payload)   { {} }
+  let(:handler)   { Travis::Hub::Handler::Job.new(nil, payload) }
+  let(:publisher) { stub('publisher', :publish => nil) }
 
   before :each do
     handler.stubs(:job).returns(job)
@@ -16,8 +17,9 @@ describe Travis::Hub::Handler::Job do
       handler.handle
     end
 
-    it 'appends the log on job:test:log' do
-      ::Job::Test.expects(:append_log!)
+    it 're-routes the message to reporting.jobs.logs' do
+      Travis::Amqp::Publisher.expects(:jobs).with('logs').returns(publisher)
+      publisher.expects(:publish).with(:data => {}, :uuid => Travis.uuid)
       handler.event = 'job:test:log'
       handler.handle
     end


### PR DESCRIPTION
This re-routes log updates to a logging queue "reporting.jobs.logs" where they can be picked up from a separate app https://github.com/travis-ci/travis-logs
