### PR TITLE
Split out enqueue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 solo:       ./bin/hub solo
 dispatcher: ./bin/hub dispatcher $DYNO_COUNT
 worker:     ./bin/hub worker $DYNO_COUNT $DYNO
+enqueue:    ./bin/hub enqueue

--- a/lib/travis/hub.rb
+++ b/lib/travis/hub.rb
@@ -9,13 +9,14 @@ require 'travis/hub/error'
 require 'travis/hub/solo'
 require 'travis/hub/worker'
 require 'travis/hub/dispatcher'
+require 'travis/hub/enqueue'
 require 'core_ext/kernel/run_periodically'
 
 $stdout.sync = true
 
 module Travis
   module Hub
-    TYPES = { 'solo' => Solo, 'worker' => Worker, 'dispatcher' => Dispatcher }
+    TYPES = { 'solo' => Solo, 'worker' => Worker, 'dispatcher' => Dispatcher, 'enqueue' => Enqueue }
     extend self
 
     def new(type = nil, *args)

--- a/lib/travis/hub/dispatcher.rb
+++ b/lib/travis/hub/dispatcher.rb
@@ -26,6 +26,10 @@ module Travis
       def queue_name(index)
         "builds.#{index + 1}"
       end
+
+      def enqueue_jobs
+        # handled by enqueue
+      end
     end
   end
 end

--- a/lib/travis/hub/enqueue.rb
+++ b/lib/travis/hub/enqueue.rb
@@ -1,0 +1,11 @@
+module Travis
+  module Hub
+    class Enqueue < Solo
+
+      def run
+        enqueue_jobs
+      end
+
+    end
+  end
+end

--- a/lib/travis/hub/solo.rb
+++ b/lib/travis/hub/solo.rb
@@ -68,16 +68,9 @@ module Travis
         end
 
         def enqueue_jobs!
-          Travis.run_service(:enqueue_jobs) unless enqueue_jobs?
+          Travis.run_service(:enqueue_jobs)
         rescue => e
           log_exception(e)
-        end
-
-        def enqueue_jobs?
-          Travis::Features.feature_active?(:travis_enqueue)
-        rescue => e
-          log_exception(e)
-          false
         end
 
         def declare_exchanges_and_queues

--- a/lib/travis/hub/solo.rb
+++ b/lib/travis/hub/solo.rb
@@ -70,7 +70,7 @@ module Travis
         def enqueue_jobs!
           Travis.run_service(:enqueue_jobs) unless enqueue_jobs?
         rescue => e
-          Travis.logging.log_exception(e)
+          log_exception(e)
         end
 
         def enqueue_jobs?

--- a/lib/travis/hub/solo.rb
+++ b/lib/travis/hub/solo.rb
@@ -22,8 +22,6 @@ module Travis
         Travis::Notification.setup
         Travis::Addons.register
 
-        Travis::Memory.new(:hub).report_periodically if Travis.env == 'production' && Travis.config.metrics.report
-
         declare_exchanges_and_queues
       end
 

--- a/lib/travis/hub/worker.rb
+++ b/lib/travis/hub/worker.rb
@@ -21,7 +21,7 @@ module Travis
       end
 
       def enqueue_jobs
-        # handled by dispatcher
+        # handled by enqueue
       end
     end
   end


### PR DESCRIPTION
Enqueue is currently taken care of within Solo and Dispatcher.

This keeps enqueue within Solo, but moves it out of Dispatcher so that Dispatcher is doing a little less.