### PR TITLE
Decrypt payload for all event handlers

### DIFF
--- a/lib/travis/addons/handlers/base.rb
+++ b/lib/travis/addons/handlers/base.rb
@@ -19,7 +19,10 @@ module Travis
         def data
           @data ||= Serializer::Generic.const_get(object_type.camelize).new(object).data
         end
-        alias payload data
+
+        def payload
+          Travis::SecureConfig.decrypt(data, secure_key)
+        end
 
         def config
           @config ||= Config.new(data, secure_key)


### PR DESCRIPTION
When handing off notification payload to travis-tasks,
ensure that the payload is decrypted.

I am opening this PR without the tests, in order to start the discussion about how this should be handled.