### PR TITLE
Switch to using a generic notifications queue for travis-tasks

### DIFF
--- a/lib/travis/addons/handlers/campfire.rb
+++ b/lib/travis/addons/handlers/campfire.rb
@@ -11,7 +11,7 @@ module Travis
         end
 
         def handle
-          run_task(:campfire, payload, targets: targets)
+          run_task(payload, targets: targets)
         end
 
         def targets

--- a/lib/travis/addons/handlers/email.rb
+++ b/lib/travis/addons/handlers/email.rb
@@ -12,7 +12,7 @@ module Travis
         end
 
         def handle
-          run_task(:email, payload, recipients: recipients, broadcasts: broadcasts)
+          run_task(payload, recipients: recipients, broadcasts: broadcasts)
         end
 
         def recipients

--- a/lib/travis/addons/handlers/flowdock.rb
+++ b/lib/travis/addons/handlers/flowdock.rb
@@ -11,7 +11,7 @@ module Travis
         end
 
         def handle
-          run_task(:flowdock, payload, targets: targets)
+          run_task(payload, targets: targets)
         end
 
         def targets
@@ -28,4 +28,3 @@ module Travis
     end
   end
 end
-

--- a/lib/travis/addons/handlers/github_status.rb
+++ b/lib/travis/addons/handlers/github_status.rb
@@ -12,7 +12,7 @@ module Travis
         end
 
         def handle
-          run_task(:github_status, payload, tokens: tokens)
+          run_task(payload, tokens: tokens)
         end
 
         private

--- a/lib/travis/addons/handlers/hipchat.rb
+++ b/lib/travis/addons/handlers/hipchat.rb
@@ -11,7 +11,7 @@ module Travis
         end
 
         def handle
-          run_task(:hipchat, payload, targets: targets)
+          run_task(payload, targets: targets)
         end
 
         def enabled?

--- a/lib/travis/addons/handlers/irc.rb
+++ b/lib/travis/addons/handlers/irc.rb
@@ -11,7 +11,7 @@ module Travis
         end
 
         def handle
-          run_task(:irc, payload, channels: channels)
+          run_task(payload, channels: channels)
         end
 
         def channels
@@ -28,4 +28,3 @@ module Travis
     end
   end
 end
-

--- a/lib/travis/addons/handlers/pusher.rb
+++ b/lib/travis/addons/handlers/pusher.rb
@@ -11,7 +11,7 @@ module Travis
           /^build:(created|received|started|finished|canceled|restarted)/,
           /^job:(created|received|started|finished|canceled|restarted)/
         ]
-        QUEUE = :'pusher-live'
+        QUEUE = :'live-updates'
 
         attr_reader :channels
 

--- a/lib/travis/addons/handlers/pushover.rb
+++ b/lib/travis/addons/handlers/pushover.rb
@@ -11,7 +11,7 @@ module Travis
         end
 
         def handle
-          run_task(:pushover, payload, users: users, api_key: api_key)
+          run_task(payload, users: users, api_key: api_key)
         end
 
         def users

--- a/lib/travis/addons/handlers/slack.rb
+++ b/lib/travis/addons/handlers/slack.rb
@@ -11,7 +11,7 @@ module Travis
         end
 
         def handle
-          run_task(:slack, payload, targets: targets)
+          run_task(payload, targets: targets)
         end
 
         def targets
@@ -28,4 +28,3 @@ module Travis
     end
   end
 end
-

--- a/lib/travis/addons/handlers/sqwiggle.rb
+++ b/lib/travis/addons/handlers/sqwiggle.rb
@@ -11,7 +11,7 @@ module Travis
         end
 
         def handle
-          run_task(:sqwiggle, payload, targets: targets)
+          run_task(payload, targets: targets)
         end
 
         def targets
@@ -28,4 +28,3 @@ module Travis
     end
   end
 end
-

--- a/lib/travis/addons/handlers/webhook.rb
+++ b/lib/travis/addons/handlers/webhook.rb
@@ -12,7 +12,7 @@ module Travis
         end
 
         def handle
-          run_task(:webhook, payload, targets: targets, token: request.token)
+          run_task(payload, targets: targets, token: request.token)
         end
 
         def targets
@@ -35,4 +35,3 @@ module Travis
     end
   end
 end
-

--- a/lib/travis/addons/helpers/task.rb
+++ b/lib/travis/addons/helpers/task.rb
@@ -30,14 +30,16 @@ module Travis
 
         include Coder
 
-        def run_task(queue, *args)
+        QUEUE = :'notifications'
+
+        def run_task(*args)
           target = "Travis::Addons::#{self.class.name.split('::').last}::Task"
           args   = deep_clean_strings(args)
 
           ::Sidekiq::Client.push(
-            'queue'   => queue,
-            'class'   => 'Travis::Async::Sidekiq::Worker',
-            'args'    => [nil, target, 'perform', *args]
+            'queue' => QUEUE,
+            'class' => 'Travis::Async::Sidekiq::Worker',
+            'args'  => [nil, target, 'perform', *args]
           )
         rescue => e
           Exceptions.handle(Error.new(e, queue, args)) # TODO pass in

--- a/spec/travis/addons/handlers/campfire_spec.rb
+++ b/spec/travis/addons/handlers/campfire_spec.rb
@@ -51,7 +51,7 @@ describe Travis::Addons::Handlers::Campfire do
 
   describe 'handle' do
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:campfire, is_a(Hash), targets: ['room'])
+      handler.expects(:run_task).with(is_a(Hash), targets: ['room'])
       handler.handle
     end
   end

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -63,7 +63,7 @@ describe Travis::Addons::Handlers::Email do
     let(:recipient)  { 'me@email.com' }
 
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:email, is_a(Hash), recipients: [recipient], broadcasts: [{ message: 'message' }])
+      handler.expects(:run_task).with(is_a(Hash), recipients: [recipient], broadcasts: [{ message: 'message' }])
       handler.handle
     end
   end

--- a/spec/travis/addons/handlers/flowdock_spec.rb
+++ b/spec/travis/addons/handlers/flowdock_spec.rb
@@ -51,7 +51,7 @@ describe Travis::Addons::Handlers::Flowdock do
 
   describe 'handle' do
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:flowdock, is_a(Hash), targets: ['room'])
+      handler.expects(:run_task).with(is_a(Hash), targets: ['room'])
       handler.handle
     end
   end

--- a/spec/travis/addons/handlers/github_status_spec.rb
+++ b/spec/travis/addons/handlers/github_status_spec.rb
@@ -45,7 +45,7 @@ describe Travis::Addons::Handlers::GithubStatus do
     before { permissions.create(user: admin, admin: true) }
 
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:github_status, is_a(Hash), tokens: { 'admin' => 'admin-token' })
+      handler.expects(:run_task).with(is_a(Hash), tokens: { 'admin' => 'admin-token' })
       handler.handle
     end
   end

--- a/spec/travis/addons/handlers/hipchat_spec.rb
+++ b/spec/travis/addons/handlers/hipchat_spec.rb
@@ -57,7 +57,7 @@ describe Travis::Addons::Handlers::Hipchat do
 
   describe 'handle' do
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:hipchat, is_a(Hash), targets: ['room'])
+      handler.expects(:run_task).with(is_a(Hash), targets: ['room'])
       handler.handle
     end
   end

--- a/spec/travis/addons/handlers/irc_spec.rb
+++ b/spec/travis/addons/handlers/irc_spec.rb
@@ -51,7 +51,7 @@ describe Travis::Addons::Handlers::Irc do
 
   describe 'handle' do
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:irc, is_a(Hash), channels: ['channel'])
+      handler.expects(:run_task).with(is_a(Hash), channels: ['channel'])
       handler.handle
     end
   end

--- a/spec/travis/addons/handlers/pusher_spec.rb
+++ b/spec/travis/addons/handlers/pusher_spec.rb
@@ -35,7 +35,7 @@ describe Travis::Addons::Handlers::Pusher do
 
       it 'enqueues a task' do
         ::Sidekiq::Client.expects(:push).with do |payload|
-          expect(payload['queue']).to   eq(:'pusher-live')
+          expect(payload['queue']).to   eq(:'live-updates')
           expect(payload['class']).to   eq('Travis::Async::Sidekiq::Worker')
           expect(payload['method']).to  eq('perform')
           expect(payload['args'][3]).to be_a(Hash)
@@ -50,7 +50,7 @@ describe Travis::Addons::Handlers::Pusher do
 
       it 'enqueues a task' do
         ::Sidekiq::Client.expects(:push).with do |payload|
-          expect(payload['queue']).to   eq(:'pusher-live')
+          expect(payload['queue']).to   eq(:'live-updates')
           expect(payload['class']).to   eq('Travis::Async::Sidekiq::Worker')
           expect(payload['method']).to  eq('perform')
           expect(payload['args'][3]).to be_a(Hash)

--- a/spec/travis/addons/handlers/pushover_spec.rb
+++ b/spec/travis/addons/handlers/pushover_spec.rb
@@ -51,7 +51,7 @@ describe Travis::Addons::Handlers::Pushover do
 
   describe 'handle' do
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:pushover, is_a(Hash), users: ['user'], api_key: 'api_key')
+      handler.expects(:run_task).with(is_a(Hash), users: ['user'], api_key: 'api_key')
       handler.handle
     end
   end

--- a/spec/travis/addons/handlers/slack_spec.rb
+++ b/spec/travis/addons/handlers/slack_spec.rb
@@ -51,7 +51,7 @@ describe Travis::Addons::Handlers::Slack do
 
   describe 'handle' do
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:slack, is_a(Hash), targets: ['room'])
+      handler.expects(:run_task).with(is_a(Hash), targets: ['room'])
       handler.handle
     end
   end

--- a/spec/travis/addons/handlers/sqwiggle_spec.rb
+++ b/spec/travis/addons/handlers/sqwiggle_spec.rb
@@ -51,7 +51,7 @@ describe Travis::Addons::Handlers::Sqwiggle do
 
   describe 'handle' do
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:sqwiggle, is_a(Hash), targets: ['room'])
+      handler.expects(:run_task).with(is_a(Hash), targets: ['room'])
       handler.handle
     end
   end

--- a/spec/travis/addons/handlers/webhook_spec.rb
+++ b/spec/travis/addons/handlers/webhook_spec.rb
@@ -41,7 +41,7 @@ describe Travis::Addons::Handlers::Webhook do
 
   describe 'handle' do
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:webhook, is_a(Hash), targets: ['http://host.com/target'], token: 'token')
+      handler.expects(:run_task).with(is_a(Hash), targets: ['http://host.com/target'], token: 'token')
       handler.handle
     end
   end


### PR DESCRIPTION
This changes hub from using 10 different notifier queues to a `notifications` queue.
Also included is a change from `pusher-live` to `live-updates`. (implementation agnostic queue)