### PR TITLE
Extract enabled? handler logic; add it to Slack

### DIFF
--- a/lib/travis/addons/handlers/base.rb
+++ b/lib/travis/addons/handlers/base.rb
@@ -47,6 +47,16 @@ module Travis
         def pull_request?
           object.pull_request?
         end
+
+        def enabled?(notifier)
+          sym = notifier.to_sym
+          pull_request? ? on_pull_request?(sym) : true
+        end
+
+        def on_pull_request?(sym)
+          value = config.values(sym, :on_pull_requests)
+          value.nil? || value
+        end
       end
     end
   end

--- a/lib/travis/addons/handlers/hipchat.rb
+++ b/lib/travis/addons/handlers/hipchat.rb
@@ -7,20 +7,11 @@ module Travis
         EVENTS = 'build:finished'
 
         def handle?
-          enabled? && targets.present? && config.send_on?(:hipchat, action)
+          enabled?(:hipchat) && targets.present? && config.send_on?(:hipchat, action)
         end
 
         def handle
           run_task(:hipchat, payload, targets: targets)
-        end
-
-        def enabled?
-          pull_request? ? on_pull_request? : true
-        end
-
-        def on_pull_request?
-          value = config.values(:hipchat, :on_pull_requests)
-          value.nil? || value
         end
 
         def targets

--- a/lib/travis/addons/handlers/slack.rb
+++ b/lib/travis/addons/handlers/slack.rb
@@ -7,7 +7,7 @@ module Travis
         EVENTS = 'build:finished'
 
         def handle?
-          targets.present? && config.send_on?(:slack, action)
+          enabled?(:slack) && targets.present? && config.send_on?(:slack, action)
         end
 
         def handle

--- a/spec/travis/addons/handlers/slack_spec.rb
+++ b/spec/travis/addons/handlers/slack_spec.rb
@@ -23,9 +23,15 @@ describe Travis::Addons::Handlers::Slack do
       expect(handler.handle?).to eql(true)
     end
 
-    it 'is true if the build is a pull request' do
+    it 'is true by default if the build is a pull request' do
       build.update_attributes(event_type: 'pull_request')
       expect(handler.handle?).to eql(true)
+    end
+
+    it 'is false if the build is a pull request and config opts out' do
+      config[:slack] = { rooms: 'room', on_pull_requests: false }
+      build.update_attributes(event_type: 'pull_request')
+      expect(handler.handle?).to eql(false)
     end
 
     it 'is true if rooms are present' do


### PR DESCRIPTION
While we have inconsistent behavior regarding PR build
notifications, those handlers which do (Slack and Hipchat)
should have a consistent mechanism to turn off PR notifications.

See https://github.com/travis-ci/travis-ci/issues/2128
and https://github.com/travis-ci/travis-ci/issues/2894
for relevant discussions.