### PR TITLE
Verify that build isn't already canceled on finish event

### DIFF
--- a/lib/travis/hub/model/build.rb
+++ b/lib/travis/hub/model/build.rb
@@ -14,7 +14,7 @@ class Build < ActiveRecord::Base
 
   event  :start,   if: :start?
   event  :finish,  if: :finish?, to: FINISHED_STATES
-  event  :cancel,  if: :cancel?
+  event  :cancel,  if: :cancel?  #TODO check if this is ever used?
   event  :restart, if: :restart?
   event  :all, after: [:denormalize, :notify]
 
@@ -29,7 +29,7 @@ class Build < ActiveRecord::Base
   end
 
   def finish?(*)
-    matrix.finished?
+    matrix.finished? && !canceled?
   end
 
   def finish(*)

--- a/lib/travis/hub/model/job.rb
+++ b/lib/travis/hub/model/job.rb
@@ -57,14 +57,10 @@ class Job < ActiveRecord::Base
   private
 
     def propagate(event, *args)
-      build.send(:"#{event}!", *args) unless build_already_canceled?(event)
+      build.send(:"#{event}!", *args)
     end
 
     def config_valid?
       !config[:'.result'].to_s.include?('error')
-    end
-
-    def build_already_canceled?(event)
-      build.canceled? && event == :finish
     end
 end

--- a/lib/travis/hub/model/job.rb
+++ b/lib/travis/hub/model/job.rb
@@ -57,10 +57,14 @@ class Job < ActiveRecord::Base
   private
 
     def propagate(event, *args)
-      build.send(:"#{event}!", *args)
+      build.send(:"#{event}!", *args) unless build_already_canceled?(event)
     end
 
     def config_valid?
       !config[:'.result'].to_s.include?('error')
+    end
+
+    def build_already_canceled?(event)
+      build.canceled? && event == 'finish'
     end
 end

--- a/lib/travis/hub/model/job.rb
+++ b/lib/travis/hub/model/job.rb
@@ -65,6 +65,6 @@ class Job < ActiveRecord::Base
     end
 
     def build_already_canceled?(event)
-      build.canceled? && event == 'finish'
+      build.canceled? && event == :finish
     end
 end

--- a/spec/travis/hub/model/build_spec.rb
+++ b/spec/travis/hub/model/build_spec.rb
@@ -189,6 +189,20 @@ describe Build do
     end
   end
 
+  describe 'a :finish event' do
+    let(:event)  { :finish }
+
+    describe 'with a :canceled state' do
+      let(:state) { :canceled }
+
+      it 'does not change its current state' do
+        receive_event = build.send(:"#{event}!", { state: state })
+        expect { receive_event }.to_not change { build.reload.state }
+        described_class.expects(:notify).never
+      end
+    end
+  end
+
   describe 'timestamps' do
     let(:job)   { FactoryGirl.create(:job, build: build) }
     let(:other) { FactoryGirl.create(:job, build: build) }


### PR DESCRIPTION
When a build has been canceled, we should send only one notification email.
We are currently sending one email for each running job on the build.
This is caused by the Jobs sending a finish event to the build, and for each finish event received the Build sends a notification: https://github.com/travis-ci/travis-hub/blob/master/lib/travis/hub/model/build.rb#L19
