### PR TITLE
Cancel enqueued builds and jobs | Improve specs

### DIFF
--- a/lib/travis/hub/model/build.rb
+++ b/lib/travis/hub/model/build.rb
@@ -63,7 +63,7 @@ class Build < ActiveRecord::Base
   end
 
   def cancel(*)
-    ## check how to set duration... self.duration    = matrix.duration
+    self.duration    = matrix.duration
     self.finished_at = Time.now
   end
 

--- a/lib/travis/hub/model/build.rb
+++ b/lib/travis/hub/model/build.rb
@@ -15,7 +15,7 @@ class Build < ActiveRecord::Base
 
   event  :start,   if: :start?
   event  :finish,  if: :finish?, to: FINISHED_STATES
-  event  :cancel,  if: :cancel?  #TODO check if this is ever used?
+  event  :cancel,  if: :cancel?
   event  :restart, if: :restart?
   event  :all, after: [:denormalize, :notify]
 
@@ -54,7 +54,7 @@ class Build < ActiveRecord::Base
   end
 
   def restart(*)
-    %w(duration started_at finished_at).each { |attr| write_attribute(attr, nil) }
+    %w(duration started_at finished_at canceled_at).each { |attr| write_attribute(attr, nil) }
     self.state = :created
   end
 

--- a/lib/travis/hub/model/build.rb
+++ b/lib/travis/hub/model/build.rb
@@ -50,7 +50,7 @@ class Build < ActiveRecord::Base
   end
 
   def restart?(*)
-    (queued? || finished? || started? || received? || matrix.restartable?) && config_valid?
+    config_valid?
   end
 
   def restart(*)
@@ -65,14 +65,6 @@ class Build < ActiveRecord::Base
   def cancel(*)
     self.duration    = matrix.duration
     self.finished_at = Time.now
-  end
-
-  def queued?
-    self.state.to_s == 'queued'
-  end
-
-  def received?
-    self.state.to_s == 'received'
   end
 
   private

--- a/lib/travis/hub/model/build.rb
+++ b/lib/travis/hub/model/build.rb
@@ -63,6 +63,9 @@ class Build < ActiveRecord::Base
   end
 
   def cancel(*)
+    self.state       = matrix.state
+    self.duration    = matrix.duration
+    self.canceled_at = Time.now
     self.finished_at = Time.now
   end
 
@@ -73,7 +76,7 @@ class Build < ActiveRecord::Base
   def received?
     self.state.to_s == 'received'
   end
-  
+
   private
 
     def matrix

--- a/lib/travis/hub/model/build.rb
+++ b/lib/travis/hub/model/build.rb
@@ -65,7 +65,6 @@ class Build < ActiveRecord::Base
   def cancel(*)
     self.state       = matrix.state
     self.duration    = matrix.duration
-    self.canceled_at = Time.now
     self.finished_at = Time.now
   end
 

--- a/lib/travis/hub/model/build.rb
+++ b/lib/travis/hub/model/build.rb
@@ -63,8 +63,7 @@ class Build < ActiveRecord::Base
   end
 
   def cancel(*)
-    self.state       = matrix.state
-    self.duration    = matrix.duration
+    ## check how to set duration... self.duration    = matrix.duration
     self.finished_at = Time.now
   end
 

--- a/lib/travis/hub/model/job.rb
+++ b/lib/travis/hub/model/job.rb
@@ -43,7 +43,7 @@ class Job < ActiveRecord::Base
 
   def restart(*)
     self.state = :created
-    %w(started_at queued_at finished_at worker).each { |attr| write_attribute(attr, nil) }
+    %w(started_at queued_at finished_at worker canceled_at).each { |attr| write_attribute(attr, nil) }
     if log
       log.clear
     else

--- a/lib/travis/hub/model/job.rb
+++ b/lib/travis/hub/model/job.rb
@@ -58,7 +58,6 @@ class Job < ActiveRecord::Base
   end
 
   def cancel(*)
-    self.canceled_at = Time.now
     self.finished_at = Time.now
   end
 

--- a/lib/travis/hub/model/job.rb
+++ b/lib/travis/hub/model/job.rb
@@ -37,10 +37,8 @@ class Job < ActiveRecord::Base
     FINISHED_STATES.include?(state.try(:to_sym))
   end
 
-  # Conditions on restart? method were added to match current tests
-  # eg. https://github.com/travis-ci/travis-hub/blob/master/spec/travis/hub/service/update_job_spec.rb#L93
   def restart?(*)
-    (finished? || started? || queued? || received?) && config_valid?
+    config_valid?
   end
 
   def restart(*)
@@ -59,14 +57,6 @@ class Job < ActiveRecord::Base
 
   def cancel(*)
     self.finished_at = Time.now
-  end
-
-  def queued?
-    self.state.to_s == 'queued'
-  end
-
-  def received?
-    self.state.to_s == 'received'
   end
 
   private

--- a/lib/travis/hub/model/job.rb
+++ b/lib/travis/hub/model/job.rb
@@ -58,6 +58,7 @@ class Job < ActiveRecord::Base
   end
 
   def cancel(*)
+    self.canceled_at = Time.now
     self.finished_at = Time.now
   end
 

--- a/lib/travis/hub/service/update_job.rb
+++ b/lib/travis/hub/service/update_job.rb
@@ -39,6 +39,7 @@ module Travis
           end
 
           def attrs
+            data[:type] = "Job::Test"
             data.reject { |key, _| key == :id }
           end
 

--- a/lib/travis/hub/service/update_job.rb
+++ b/lib/travis/hub/service/update_job.rb
@@ -39,7 +39,6 @@ module Travis
           end
 
           def attrs
-            data[:type] = "Job::Test"
             data.reject { |key, _| key == :id }
           end
 

--- a/spec/travis/hub/model/build_spec.rb
+++ b/spec/travis/hub/model/build_spec.rb
@@ -91,6 +91,11 @@ describe Build do
       expect(build.reload.finished_at).to be_nil
     end
 
+    it 'resets :canceled_at' do
+      receive
+      expect(build.reload.canceled_at).to be_nil
+    end
+
     it 'dispatches a build:restarted event' do
       Travis::Event.expects(:dispatch).with('build:restarted', id: build.id)
       receive

--- a/spec/travis/hub/model/build_spec.rb
+++ b/spec/travis/hub/model/build_spec.rb
@@ -137,6 +137,16 @@ describe Build do
       include_examples 'cancels the build'
     end
 
+    describe 'received by a :queued build' do
+      let(:state) { :queued }
+      include_examples 'cancels the build'
+    end
+
+    describe 'received by a :received build' do
+      let(:state) { :received }
+      include_examples 'cancels the build'
+    end
+
     describe 'received by a :started build' do
       let(:state) { :started }
       include_examples 'cancels the build'
@@ -161,6 +171,7 @@ describe Build do
       let(:state) { :canceled }
       include_examples 'does not apply'
     end
+
   end
 
   describe 'a :start event' do
@@ -203,6 +214,11 @@ describe Build do
       include_examples 'restarts the build'
     end
 
+    describe 'received by a :received build' do
+      let(:state) { :received }
+      include_examples 'restarts the build'
+    end
+
     describe 'received by a :started build' do
       let(:state) { :started }
       include_examples 'restarts the build'
@@ -227,6 +243,7 @@ describe Build do
       let(:state) { :canceled }
       include_examples 'restarts the build'
     end
+
   end
 
   describe 'a :finish event' do

--- a/spec/travis/hub/model/build_spec.rb
+++ b/spec/travis/hub/model/build_spec.rb
@@ -32,9 +32,22 @@ describe Build do
     end
 
     describe 'with all other jobs being finished' do
+      let(:job)   { FactoryGirl.create(:job, build: build, state: :canceled, finished_at: now, started_at: now - 2.minute) }
+
       it 'sets the build to :canceled' do
         receive
         expect(build.reload.state).to eql(:canceled)
+      end
+
+      it 'sets :duration' do
+        job
+        receive
+        expect(build.reload.duration.to_i).to eql(job.duration.to_i)
+      end
+
+      it 'sets :canceled_at' do
+        receive
+        expect(build.reload.canceled_at).to eql(now)
       end
     end
 

--- a/spec/travis/hub/model/job_spec.rb
+++ b/spec/travis/hub/model/job_spec.rb
@@ -216,6 +216,11 @@ describe Job do
       expect(job.reload.finished_at).to be_nil
     end
 
+    it 'resets :canceled_at' do
+      receive
+      expect(job.reload.canceled_at).to be_nil
+    end
+
     it 'dispatches a job:restarted event' do
       Travis::Event.expects(:dispatch).with('job:restarted', id: job.id)
       receive

--- a/spec/travis/hub/model/job_spec.rb
+++ b/spec/travis/hub/model/job_spec.rb
@@ -249,14 +249,6 @@ describe Job do
       end
     end
 
-    describe 'received state' do
-      it 'restarts the job' do
-        job.state = :received
-        receive
-        expect(job.reload.state).to eql(:created)
-      end
-    end
-
     describe 'it denormalizes to the repository' do
       %w(state duration started_at finished_at).each do |attr|
         it "sets last_build_#{attr}" do
@@ -434,6 +426,11 @@ describe Job do
 
     describe 'received by a :queued job' do
       let(:state) { :queued }
+      include_examples 'restarts the job'
+    end
+
+    describe 'received by a :received job' do
+      let(:state) { :received }
       include_examples 'restarts the job'
     end
 

--- a/spec/travis/hub/service/update_build_spec.rb
+++ b/spec/travis/hub/service/update_build_spec.rb
@@ -78,6 +78,16 @@ describe Travis::Hub::Service::UpdateBuild do
       expect(job.reload.state).to eql(:canceled)
     end
 
+    it 'sets :finished_at' do
+      subject.run
+      expect(build.reload.finished_at).to eql(now)
+    end
+
+    it 'sets :canceled_at' do
+      subject.run
+      expect(build.reload.canceled_at).to eql(now)
+    end
+
     it 'instruments #run' do
       subject.run
       expect(stdout.string).to include("Travis::Hub::Service::UpdateBuild#run:completed event: cancel for repo=travis-ci/travis-core id=#{build.id}")

--- a/spec/travis/hub/service/update_job_spec.rb
+++ b/spec/travis/hub/service/update_job_spec.rb
@@ -57,10 +57,12 @@ describe Travis::Hub::Service::UpdateJob do
     let(:state) { :created }
     let(:event) { :cancel }
     let(:data)  { { id: job.id } }
+    let(:now) { Time.now }
 
     it 'updates the job' do
       subject.run
       expect(job.reload.state).to eql(:canceled)
+      expect(job.reload.canceled_at).to eql(now)
     end
 
     it 'instruments #run' do


### PR DESCRIPTION
- Deletes `restart?` conditions and improves specs by adding tests for `received` state.
- Resets `canceled_at` attribute on restart event, in order for it to be set when a cancel event arrives. 
- Sets type to ` data[:type] = "Job::Test" ` in Update_Job action, since when it comes from a build, sometimes the attr: `data[:type]` is set to build and causes conflicts on the DB.
- Sets build's duration on cancel event, it refers to the matrix.duration.
 


