### PR TITLE
Set current_build_id also for PRs

### DIFF
--- a/lib/travis/hub/update_current_build.rb
+++ b/lib/travis/hub/update_current_build.rb
@@ -7,6 +7,7 @@ module Travis
 
       def update!
         logger.info MSGS[:update] % [build.id, repository.id]
+        p [:is_current, is_current?]
         if is_current?
           repository.update_attributes!(current_build_id: build.id)
         end
@@ -15,16 +16,12 @@ module Travis
       private
 
         def is_current?
-          return false if build.pull_request?
-
           states = ['started', 'passed', 'failed', 'errored', 'canceled']
-          event_types = ['api', 'cron', 'push']
 
           # the build is not current if there're any newer builds that
           # are being run or finshed already
           !repository.builds.where(["id > ?", build.id]).
-                             where(state: states).
-                             where(event_type: event_types).exists?
+                      where(state: states).exists?
         end
 
         def repository

--- a/spec/travis/hub/model/build_spec.rb
+++ b/spec/travis/hub/model/build_spec.rb
@@ -184,19 +184,14 @@ describe Build do
 
     describe 'a pull request' do
       let!(:build) { FactoryGirl.create(:build, repository: repo, state: :created, event_type: 'pull_request') }
-      it 'does not set the build as current build' do
+      it 'sets the build as current build' do
         receive
-        repo.reload.current_build_id.should_not == build.id
+        repo.reload.current_build_id.should == build.id
       end
     end
 
     describe 'a push build' do
       let!(:build) { FactoryGirl.create(:build, repository: repo, state: :created, event_type: 'push') }
-      it 'sets the build as current build if there are no other builds non pull request builds' do
-        FactoryGirl.create(:build, repository: repo, state: :started, event_type: 'pull_request')
-        receive
-        repo.reload.current_build_id.should == build.id
-      end
 
       it 'does not set the build as current build if any newer builds exist in started of one of the finished states' do
         FactoryGirl.create(:build, repository: repo, state: :started, event_type: 'api')


### PR DESCRIPTION
current_build was meant to be similar to last_build on repository, just
more predictable. It turns out that last_build was set also for PRs.
This commit changes current_build udpate code to also update
current_build_id for PRs