### PR TITLE
Bumped travis-config to the latest version for some HA bug fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     thread_safe (0.3.5-java)
     timers (4.1.1)
       hitimes
-    travis-config (1.0.6)
+    travis-config (1.0.12)
       hashr (~> 2.0.0)
     travis-encrypt (0.0.1)
     tzinfo (1.2.2)
@@ -210,4 +210,4 @@ DEPENDENCIES
   unlimited-jce-policy-jdk7!
 
 BUNDLED WITH
-   1.11.2
+   1.12.4


### PR DESCRIPTION
Much like: https://github.com/travis-ci/travis-listener/pull/16, pulling in the latest version of `travis-config` to fix some issues that came up in the latest build of Enterprise 2.0. 