### PR TITLE
Fix remove log after restart

### DIFF
--- a/lib/travis/hub/model/log.rb
+++ b/lib/travis/hub/model/log.rb
@@ -10,7 +10,8 @@ class Log < ActiveRecord::Base
     update_column(:aggregated_at, nil) # TODO why in the world does update_attributes not set aggregated_at to nil?
     update_column(:archived_at, nil)
     update_column(:archive_verified, nil)
-
+    update_column(:removed_at, nil)
+    update_column(:removed_by, nil)
     Part.where(log_id: id).delete_all
   end
 end

--- a/spec/travis/hub/model/job_spec.rb
+++ b/spec/travis/hub/model/job_spec.rb
@@ -247,6 +247,14 @@ describe Job do
         expect(job.build.reload.finished_at).to be_nil
       end
 
+      it 'clears log' do
+        receive
+        expect(job.log.reload.content).to be_nil
+        expect(job.log.reload.archive_verified).to be_nil
+        expect(job.log.reload.removed_by).to be_nil
+        expect(job.log.reload.removed_at).to be_nil
+      end
+
       it 'does not restart other jobs on the matrix' do
         other = FactoryGirl.create(:job, build: job.build, state: :passed)
         receive

--- a/spec/travis/hub/model/job_spec.rb
+++ b/spec/travis/hub/model/job_spec.rb
@@ -249,7 +249,7 @@ describe Job do
 
       it 'clears log' do
         receive
-        expect(job.log.reload.content).to be_nil
+        expect(job.log.reload.content).to be_empty
         expect(job.log.reload.archive_verified).to be_nil
         expect(job.log.reload.removed_by).to be_nil
         expect(job.log.reload.removed_at).to be_nil


### PR DESCRIPTION
`removed_at` and `removed_by` attributes need to be reset after restart, in order to enable log removal 