### PR TITLE
Re-broadcast on events for canceled jobs

### DIFF
--- a/lib/travis/hub/service/notify_workers.rb
+++ b/lib/travis/hub/service/notify_workers.rb
@@ -2,7 +2,14 @@ module Travis
   module Hub
     module Service
       class NotifyWorkers < Struct.new(:context)
+        include Helper::Context
+
+        MSGS = {
+          cancel: 'Broadcasting cancelation message for <Job id=%s state=%s>',
+        }
+
         def cancel(job)
+          info :cancel, job.state, job.id
           context.amqp.fanout('worker.commands', type: 'cancel_job', job_id: job.id, source: 'hub')
         end
       end


### PR DESCRIPTION
Relevant for https://github.com/travis-pro/team-teal/issues/1420

Apparently this used to be a feature at some point. If so we might have dropped it when removing core.