### PR TITLE
Add cancel event to webhook

### DIFF
--- a/lib/travis/addons/config/notify.rb
+++ b/lib/travis/addons/config/notify.rb
@@ -10,7 +10,8 @@ module Travis
         DEFAULTS = {
           start:   { email: false,   webhooks: false,   campfire: false,   hipchat: false,   irc: false,   flowdock: false,   sqwiggle: false,   slack: false,   pushover: false   },
           success: { email: :change, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always },
-          failure: { email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always }
+          failure: { email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always },
+          canceled:{ email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always }
         }
 
         attr_reader :build, :config
@@ -51,7 +52,7 @@ module Travis
 
           def on_canceled_for?(type)
             !!if build_canceled?
-              config = with_fallbacks(type, :on_cancel, DEFAULTS[:failure][type])
+              config = with_fallbacks(type, :on_cancel, DEFAULTS[:canceled][type])
               config == :always || config == :change && (previous_build_passed? || initial_build?)
             end
           end

--- a/lib/travis/addons/config/notify.rb
+++ b/lib/travis/addons/config/notify.rb
@@ -11,7 +11,8 @@ module Travis
           start:   { email: false,   webhooks: false,   campfire: false,   hipchat: false,   irc: false,   flowdock: false,   sqwiggle: false,   slack: false,   pushover: false   },
           success: { email: :change, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always },
           failure: { email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always },
-          canceled:{ email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always }
+          canceled:{ email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always },
+          errored: { email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always }
         }
 
         attr_reader :build, :config
@@ -53,6 +54,13 @@ module Travis
           def on_canceled_for?(type)
             !!if build_canceled?
               config = with_fallbacks(type, :on_cancel, DEFAULTS[:canceled][type])
+              config == :always || config == :change && (previous_build_passed? || initial_build?)
+            end
+          end
+
+          def on_errored_for?(type)
+            !!if build_errored?
+              config = with_fallbacks(type, :on_cancel, DEFAULTS[:errored][type])
               config == :always || config == :change && (previous_build_passed? || initial_build?)
             end
           end

--- a/lib/travis/addons/config/notify.rb
+++ b/lib/travis/addons/config/notify.rb
@@ -49,12 +49,23 @@ module Travis
             end
           end
 
+          def on_canceled_for?(type)
+            !!if build_canceled?
+              config = with_fallbacks(type, :on_cancel, DEFAULTS[:failure][type])
+              config == :always || config == :change && (previous_build_passed? || initial_build?)
+            end
+          end
+
           def initial_build?
             blank?(build[:previous_state])
           end
 
           def build_passed?
             build[:state].try(:to_sym) == :passed
+          end
+
+          def build_canceled?
+            build[:state].try(:to_sym) == :canceled
           end
 
           def build_failed?

--- a/lib/travis/addons/handlers/webhook.rb
+++ b/lib/travis/addons/handlers/webhook.rb
@@ -5,7 +5,7 @@ module Travis
   module Addons
     module Handlers
       class Webhook < Base
-        EVENTS = /build:(started|finished)/
+        EVENTS = /build:(started|finished|canceled)/
 
         def handle?
           targets.present? && config.send_on?(:webhooks, action)
@@ -35,4 +35,3 @@ module Travis
     end
   end
 end
-

--- a/lib/travis/addons/handlers/webhook.rb
+++ b/lib/travis/addons/handlers/webhook.rb
@@ -5,7 +5,7 @@ module Travis
   module Addons
     module Handlers
       class Webhook < Base
-        EVENTS = /build:(started|finished|canceled)/
+        EVENTS = /build:(started|finished|canceled|errored)/
 
         def handle?
           targets.present? && config.send_on?(:webhooks, action)

--- a/spec/travis/addons/handlers/webhook_spec.rb
+++ b/spec/travis/addons/handlers/webhook_spec.rb
@@ -15,6 +15,12 @@ describe Travis::Addons::Handlers::Webhook do
       described_class.expects(:notify)
       Travis::Event.dispatch('build:finished', id: build.id)
     end
+
+    it 'build:canceled notifies' do
+      described_class.new('build:canceled', id: build.id)
+      described_class.expects(:notify)
+      Travis::Event.dispatch('build:canceled', id: build.id)
+    end
   end
 
   describe 'handle?' do
@@ -78,6 +84,11 @@ describe Travis::Addons::Handlers::Webhook do
     it 'returns an array of targets given a comma separated string within a hash' do
       config[:webhooks] = { urls: "#{target}, #{other}", on_success: 'change' }
       expect(handler.targets).to eql [target, other]
+    end
+
+    it 'returns an array of targets given a string within a hash on_cancel' do
+      config[:webhooks] = { urls: target, on_cancel: 'change' }
+      expect(handler.targets).to eql [target]
     end
   end
 end

--- a/spec/travis/addons/handlers/webhook_spec.rb
+++ b/spec/travis/addons/handlers/webhook_spec.rb
@@ -21,6 +21,12 @@ describe Travis::Addons::Handlers::Webhook do
       described_class.expects(:notify)
       Travis::Event.dispatch('build:canceled', id: build.id)
     end
+
+    it 'build:errored notifies' do
+      described_class.new('build:errored', id: build.id)
+      described_class.expects(:notify)
+      Travis::Event.dispatch('build:errored', id: build.id)
+    end
   end
 
   describe 'handle?' do


### PR DESCRIPTION
Add cancel event to webhook, currently we only send notifications when the build fails