### PR TITLE
add check for single bad build

### DIFF
--- a/lib/travis/hub/service/update_build.rb
+++ b/lib/travis/hub/service/update_build.rb
@@ -15,6 +15,7 @@ module Travis
 
         def run
           exclusive do
+            return if data[:id] == 187764488
             validate
             update_jobs
             notify


### PR DESCRIPTION
This is a temporary fix to ignore jobs from problematic build with massive matrix and enable cancellation. 