### PR TITLE
Port: Setup exchanges and queues for enterprise

### DIFF
--- a/lib/travis/hub/context.rb
+++ b/lib/travis/hub/context.rb
@@ -23,7 +23,7 @@ module Travis
         @exceptions = Travis::Exceptions.setup(config, config.env, logger)
         @metrics    = Travis::Metrics.setup(config.metrics, logger)
         @redis      = Travis::RedisPool.new(config.redis.to_h)
-        @amqp       = Travis::Amqp.setup(config.amqp)
+        @amqp       = Travis::Amqp.setup(config.amqp, @config.enterprise?)
 
         Travis::Database.connect(ActiveRecord::Base, config.database, logger)
         Travis::Sidekiq.setup(config)

--- a/lib/travis/hub/support/amqp.rb
+++ b/lib/travis/hub/support/amqp.rb
@@ -21,8 +21,10 @@ module Travis
 
     def setup
       # TODO required on enterprise. move details to config?
-      channel.exchange('reporting', durable: true, auto_delete: false, type: :topic)
-      channel.queue('builds.linux', durable: true, exclusive: false)
+      if Travis.config.enterprise?
+        channel.exchange('reporting', durable: true, auto_delete: false, type: :topic)
+        channel.queue('builds.linux', durable: true, exclusive: false)
+      end
     end
 
     def subscribe(queue, options, &handler)


### PR DESCRIPTION
In Enterprise we need to setup the exchanges and queues for things to be where they should be when starting a new instance.  

This commit was originally in `enterprise-2.0` but never made it into master. I cherry-picked the original commit by @svenfuchs but will be wrapping it in a conditional so we don't setup a new one each time in production, only in Enterprise. 

