### PR TITLE
Update scheduler queue since we're on 2 now

### DIFF
--- a/lib/travis/sidekiq.rb
+++ b/lib/travis/sidekiq.rb
@@ -14,7 +14,7 @@ module Travis
 
     def scheduler(*args)
       client.push(
-        'queue' => ENV['SCHEDULER_SIDEKIQ_QUEUE'] || 'scheduler-2', # TODO use 'scheduler' once Scheduler 2.0 is fully rolled out
+        'queue' => ENV['SCHEDULER_SIDEKIQ_QUEUE'] || 'scheduler'
         'class' => 'Travis::Scheduler::Worker',
         'args'  => [:event, *args]
       )

--- a/lib/travis/sidekiq.rb
+++ b/lib/travis/sidekiq.rb
@@ -14,7 +14,7 @@ module Travis
 
     def scheduler(*args)
       client.push(
-        'queue' => ENV['SCHEDULER_SIDEKIQ_QUEUE'] || 'scheduler'
+        'queue' => ENV['SCHEDULER_SIDEKIQ_QUEUE'] || 'scheduler',
         'class' => 'Travis::Scheduler::Worker',
         'args'  => [:event, *args]
       )

--- a/spec/travis/addons/handlers/scheduler_spec.rb
+++ b/spec/travis/addons/handlers/scheduler_spec.rb
@@ -35,7 +35,7 @@ describe Travis::Addons::Handlers::Scheduler do
   describe 'handle' do
     it 'notifies scheduler' do
       ::Sidekiq::Client.expects(:push).with(
-        'queue' => 'scheduler-2',
+        'queue' => 'scheduler',
         'class' => 'Travis::Scheduler::Worker',
         'args'  => [:event, 'job:finished', id: job.id]
       )


### PR DESCRIPTION
Ran into an issue where job restarts weren't triggering builds but would trigger one once a new build happened. 

Turns out we were still using a queue no one was listening to. So this fixes that. 