### PR TITLE
order branches query by name to speed up query

### DIFF
--- a/lib/travis/addons/serializer/pusher/build.rb
+++ b/lib/travis/addons/serializer/pusher/build.rb
@@ -118,7 +118,7 @@ module Travis
             end
 
             def last_build_on_default_branch_id(repository)
-              default_branch = Branch.where(repository_id: repository.id, name: repository.default_branch).first
+              default_branch = Branch.where(repository_id: repository.id, name: repository.default_branch).order('name ASC').first
 
               if default_branch
                 default_branch.last_build_id


### PR DESCRIPTION
the query that `ActiveRecord::FinderMethods#first` generates adds an order
by id. in this case that results in a very slow because it makes postgres
use the wrong index.

this patch attempts to remedy that query by introducing a custom order clause.

refs travis-pro/team-teal#1834