### PR TITLE
cron: add event_type to build payload

### DIFF
--- a/lib/travis/addons/serializer/generic/build.rb
+++ b/lib/travis/addons/serializer/generic/build.rb
@@ -42,7 +42,8 @@ module Travis
                 started_at: format_date(build.started_at),
                 finished_at: format_date(build.finished_at),
                 duration: build.duration,
-                job_ids: build.jobs.map(&:id)
+                job_ids: build.jobs.map(&:id),
+                event_type: build.event_type
               }
             end
 

--- a/spec/travis/addons/serializer/generic/build_spec.rb
+++ b/spec/travis/addons/serializer/generic/build_spec.rb
@@ -19,7 +19,8 @@ describe Travis::Addons::Serializer::Generic::Build do
       previous_state: nil,
       started_at: nil,
       finished_at: nil,
-      duration: nil
+      duration: nil,
+      event_type: 'push'
     )
   end
 


### PR DESCRIPTION
this is needed by tasks to decide if a build was cron-triggered.

refs https://github.com/travis-ci/travis-tasks/pull/84.