### PR TITLE
Create a Docker image on each commit and push to Quay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,21 @@ before_script:
 
 script:
   - bundle exec rspec
+
+
+jobs:
+  include:
+    - stage: "testing time"
+    - stage: ":ship: it to Quay.io"
+      sudo: required
+      dist: trusty
+      ruby:
+      services:
+      addons:
+      before_install: skip
+      install: skip
+      before_script:
+        - curl -L https://github.com/docker/compose/releases/download/1.13.0/docker-compose-`uname -s`-`uname -m` > ./docker-compose
+        - sudo mv ./docker-compose /usr/local/bin/docker-compose
+        - sudo chmod +x /usr/local/bin/docker-compose
+      script: ./script/docker-build-and-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.2.2
+
+LABEL maintainer Travis CI GmbH <support+travis-app-docker-images@travis-ci.com>
+
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile      /usr/src/app
+COPY Gemfile.lock /usr/src/app
+
+ARG bundle_gems__contribsys__com
+RUN bundle config https://gems.contribsys.com/ $bundle_gems__contribsys__com \
+      && bundle install --deployment \
+      && bundle config --delete https://gems.contribsys.com/
+
+COPY . /usr/src/app
+
+CMD /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: "2"
+services:
+  hub:
+    build: .

--- a/script/docker-build-and-push
+++ b/script/docker-build-and-push
@@ -16,8 +16,8 @@ docker tag $local_image $quay_image:${TRAVIS_COMMIT:0:7};
 docker push $quay_image:${TRAVIS_COMMIT:0:7};
 
 if [ ${TRAVIS_BRANCH} = "master" ]; then
-  docker tag $local_image $quay_image:latest";
-  docker push $quay_image:$TRAVIS_BRANCH";
+  docker tag $local_image $quay_image:latest;
+  docker push $quay_image:$TRAVIS_BRANCH;
 fi
 
 exit 0;

--- a/script/docker-build-and-push
+++ b/script/docker-build-and-push
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ev
+app_name="hub"
+local_image="travishub_$app_name" # Docker Compose removes dashes and expects the name to end with the build app name
+quay_image=quay.io/travisci/travis-hub;
+
+docker-compose build --build-arg bundle_gems__contribsys__com="$BUNDLE_GEMS__CONTRIBSYS__COM" "$app_name";
+docker login -u="$QUAY_ROBOT_HANDLE" -p="$QUAY_ROBOT_TOKEN" quay.io;
+docker images;
+
+docker tag $local_image $quay_image:$TRAVIS_BRANCH;
+docker push $quay_image:$TRAVIS_BRANCH;
+
+docker tag $local_image $quay_image:${TRAVIS_COMMIT:0:7};
+docker push $quay_image:${TRAVIS_COMMIT:0:7};
+
+if [ ${TRAVIS_BRANCH} = "master" ]; then
+  docker tag $local_image $quay_image:latest";
+  docker push $quay_image:$TRAVIS_BRANCH";
+fi
+
+exit 0;


### PR DESCRIPTION
This adds a build stage which builds and pushes a private Docker image to Quay.io

You can find it here: https://quay.io/repository/travisci/travis-hub?tab=tags

All commits are built, all pushes are tagged with the commit ref, the branch name, and with latest if the branch is master.

In the Travis settings UI, a QUAY_ROBOT_HANDLE and QUAY_ROBOT_TOKEN is configured per quay repo for pushing the Docker image.

@joshk and I have been talking about this setup for all Travis apps so that Enterprise can use them.