### PR TITLE
Include SSL options in Faraday call for self signed certs in Enterprise

### DIFF
--- a/lib/travis/hub/config.rb
+++ b/lib/travis/hub/config.rb
@@ -42,7 +42,8 @@ module Travis
              queue:          'builds',
              limit:          { resets: { max: 50, after: 6 * 60 * 60 } },
              notifications:  [],
-             auth:           { jwt_public_key: ENV['JWT_RSA_PUBLIC_KEY'], http_basic_auth: http_basic_auth }
+             auth:           { jwt_public_key: ENV['JWT_RSA_PUBLIC_KEY'], http_basic_auth: http_basic_auth },
+             ssl:            {}
 
       def metrics
         # TODO cleanup keychain?

--- a/lib/travis/hub/config.rb
+++ b/lib/travis/hub/config.rb
@@ -42,8 +42,7 @@ module Travis
              queue:          'builds',
              limit:          { resets: { max: 50, after: 6 * 60 * 60 } },
              notifications:  [],
-             auth:           { jwt_public_key: ENV['JWT_RSA_PUBLIC_KEY'], http_basic_auth: http_basic_auth },
-             ssl:            {}
+             auth:           { jwt_public_key: ENV['JWT_RSA_PUBLIC_KEY'], http_basic_auth: http_basic_auth }
 
       def metrics
         # TODO cleanup keychain?

--- a/lib/travis/hub/support/logs.rb
+++ b/lib/travis/hub/support/logs.rb
@@ -31,7 +31,7 @@ module Travis
         private
 
           def client
-            @client ||= Faraday.new(url: url) do |c|
+            @client ||= Faraday.new(http_options.merge(url: url)) do |c|
               c.request :authorization, :token, token
               c.request :retry, max: 5, interval: 0.1, backoff_factor: 2
               c.response :raise_error
@@ -45,6 +45,10 @@ module Travis
 
           def token
             config[:token] || raise('Logs token not set.')
+          end
+
+          def http_options
+            { ssl: Travis.config.ssl.compact.to_h }
           end
       end
     end

--- a/lib/travis/hub/support/logs.rb
+++ b/lib/travis/hub/support/logs.rb
@@ -48,7 +48,11 @@ module Travis
           end
 
           def http_options
-            { ssl: config.ssl.compact.to_h }
+            if config.ssl
+              { ssl: config.ssl.compact.to_h }
+            else
+              {}
+            end
           end
       end
     end

--- a/lib/travis/hub/support/logs.rb
+++ b/lib/travis/hub/support/logs.rb
@@ -6,7 +6,7 @@ module Travis
       class Logs < Struct.new(:config)
         def update(id, msg, clear: false)
           client.put do |req|
-            req.url "/logs/#{id}"
+            req.url "logs/#{id}"
             req.params['source'] = 'hub'
             req.params['clear'] = '1' if clear
             req.headers['Content-Type'] = 'application/octet-stream'
@@ -16,7 +16,7 @@ module Travis
 
         def append_log_part(id, part, final: false)
           client.put do |req|
-            req.url "/log-parts/#{id}/last"
+            req.url "log-parts/#{id}/last"
             req.params['source'] = 'hub'
             req.headers['Content-Type'] = 'application/json'
             req.body = JSON.dump(

--- a/lib/travis/hub/support/logs.rb
+++ b/lib/travis/hub/support/logs.rb
@@ -48,7 +48,7 @@ module Travis
           end
 
           def http_options
-            { ssl: Travis.config.ssl.compact.to_h }
+            { ssl: config.ssl.compact.to_h }
           end
       end
     end

--- a/spec/travis/hub/service/update_job_spec.rb
+++ b/spec/travis/hub/service/update_job_spec.rb
@@ -165,7 +165,7 @@ describe Travis::Hub::Service::UpdateJob do
     end
 
     describe 'with resets being limited' do
-      let(:url)     { 'http://logs.travis-ci.org/logs' }
+      let(:url)     { 'http://logs.travis-ci.org/' }
       let(:started) { Time.now - 7 * 3600 }
       let(:limit)   { Travis::Hub::Limit.new(redis, :resets, job.id) }
       let(:state)   { :queued }


### PR DESCRIPTION
Related to: https://github.com/travis-ci/travis-api/pull/514

Essentially the same issue we saw there, need to pass in the SSL options in Enterprise since we add self signed certs to the CA file. 

