### PR TITLE
Send `user_ids` along with pusher data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'travis-config',          git: 'https://github.com/travis-ci/travis-config'
 gem 'travis-encrypt'
 gem 'travis-lock',            git: 'https://github.com/travis-ci/travis-lock'
 gem 'travis-support',         git: 'https://github.com/travis-ci/travis-support'
+gem 'travis-rollout',         git: 'https://github.com/travis-ci/travis-rollout', branch: 'sf-refactor'
 
 gem 'rake'
 gem 'jemalloc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,13 @@ GIT
       metriks-librato_metrics (~> 1.0)
 
 GIT
+  remote: https://github.com/travis-ci/travis-rollout
+  revision: 71cc9102dff01f95c281f99183e54b6695faa7ec
+  branch: sf-refactor
+  specs:
+    travis-rollout (0.0.1)
+
+GIT
   remote: https://github.com/travis-ci/travis-support
   revision: 113cff17fe383bb72fcfae3a97a8ce98c228342f
   specs:
@@ -215,8 +222,9 @@ DEPENDENCIES
   travis-lock!
   travis-logger!
   travis-metrics!
+  travis-rollout!
   travis-support!
   webmock
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/spec/travis/addons/handlers/pusher_spec.rb
+++ b/spec/travis/addons/handlers/pusher_spec.rb
@@ -1,6 +1,8 @@
 describe Travis::Addons::Handlers::Pusher do
-  let(:build)   { FactoryGirl.create(:build, config: { notifications: config }) }
-  let(:job)     { FactoryGirl.create(:job) }
+  let(:user)    { FactoryGirl.create(:user) }
+  let(:repo)    { FactoryGirl.create(:repository, owner: user) }
+  let(:build)   { FactoryGirl.create(:build, repository: repo, config: { notifications: config }) }
+  let(:job)     { FactoryGirl.create(:job, repository: repo) }
   let(:config)  { { pusher: 'room' } }
 
   describe 'subscription' do
@@ -41,6 +43,27 @@ describe Travis::Addons::Handlers::Pusher do
           expect(payload['args'][4]).to eq(event: event)
         end
         handler.handle
+      end
+
+      context 'with a per user channel enabled' do
+        before do
+          user.permissions.create!(repository: repo)
+        end
+
+        it 'sends user_ids along with the request' do
+          redis = Travis::Hub.context.redis
+          repo = job.repository
+          redis.sadd('user-channel.rollout.uids', "#{repo.owner.id}-#{repo.owner_type[0]}")
+          redis.set('user-channel.rollout.enabled', '1')
+
+          ::Sidekiq::Client.expects(:push).with do |payload|
+            expect(payload['queue']).to   eq('pusher-live')
+            expect(payload['class']).to   eq('Travis::Async::Sidekiq::Worker')
+            expect(payload['args'][3]).to be_a(Hash)
+            expect(payload['args'][4]).to eq(event: event, user_ids: [user.id])
+          end
+          handler.handle
+        end
       end
     end
 


### PR DESCRIPTION
This PR allows to enable per-user channels by sending `user_ids` along
with the pusher payload. That way we can send the message to user based
channels instead of repo based channels.

I've used travis-rollout to allow enabling it only for certain owners and then roll it out gradually.