### PR TITLE
Send job cancellations directly to Job Board

### DIFF
--- a/lib/travis/hub/config.rb
+++ b/lib/travis/hub/config.rb
@@ -1,36 +1,27 @@
+require 'hashr'
 require 'travis/config'
 require 'travis/config/heroku'
 
 module Travis
   module Hub
     class Config < Travis::Config
+      extend Hashr::Env
+
       class << self
         def http_basic_auth
           tokens = ENV['HTTP_BASIC_AUTH'] || ''
           tokens.split(',').map { |token| token.split(':').map(&:strip) }.to_h
         end
-
-        def logs_api_url
-          ENV['TRAVIS_HUB_LOGS_API_URL'] ||
-            ENV['LOGS_API_URL'] ||
-            'http://travis-logs-notset.example.com:1234'
-        end
-
-        def logs_api_auth_token
-          ENV['TRAVIS_HUB_LOGS_API_AUTH_TOKEN'] ||
-            ENV['LOGS_API_AUTH_TOKEN'] ||
-            'notset'
-        end
       end
 
       define amqp:           { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
              database:       { adapter: 'postgresql', database: "travis_#{env}", encoding: 'unicode', min_messages: 'warning', pool: 25, reaping_frequency: 60, variables: { statement_timeout: 10000 } },
-             logs_api:       { url: logs_api_url, token: logs_api_auth_token },
+             logs_api:       { url: 'https://travis-logs-notset.example.com:1234', token: 'notset' },
+             job_board:      { url: 'https://not:set@job-board.travis-ci.com', site: 'org' },
              redis:          { url: 'redis://localhost:6379' },
              sidekiq:        { namespace: 'sidekiq', pool_size: 1 },
              lock:           { strategy: :redis },
              states_cache:   { memcached_servers: 'localhost:11211', memcached_options: {} },
-             logs:           { url: ENV['LOGS_URL'], token: ENV['LOGS_TOKEN'] },
              name:           'hub',
              host:           'travis-ci.org',
              encryption:     env == 'development' || env == 'test' ? { key: 'secret' * 10 } : {},

--- a/lib/travis/hub/context.rb
+++ b/lib/travis/hub/context.rb
@@ -43,7 +43,7 @@ module Travis
           # TODO move keen to the keychain? it isn't required on enterprise.
           # then again, it's not active, unless the keen credentials are
           # present in the env.
-          config.notifications + ['scheduler', 'keenio']
+          config.notifications.flatten + ['scheduler', 'keenio']
         end
 
         def test_exception_reporting

--- a/lib/travis/hub/service/notify_workers.rb
+++ b/lib/travis/hub/service/notify_workers.rb
@@ -1,3 +1,5 @@
+require 'travis/hub/support/job_board'
+
 module Travis
   module Hub
     module Service
@@ -10,8 +12,28 @@ module Travis
 
         def cancel(job)
           info :cancel, job.id, job.state
-          context.amqp.fanout('worker.commands', type: 'cancel_job', job_id: job.id, source: 'hub')
+          cancel_via_job_board(job)
+          cancel_via_amqp(job)
         end
+
+        private
+
+          def cancel_via_job_board(job)
+            job_board.cancel(job.id)
+          end
+
+          def cancel_via_amqp(job)
+            context.amqp.fanout(
+              'worker.commands',
+              type: 'cancel_job', job_id: job.id, source: 'hub'
+            )
+          end
+
+          def job_board
+            @job_board ||= Travis::Hub::Support::JobBoard.new(
+              context.config.job_board.to_h
+            )
+          end
       end
     end
   end

--- a/lib/travis/hub/service/notify_workers.rb
+++ b/lib/travis/hub/service/notify_workers.rb
@@ -7,11 +7,11 @@ module Travis
         include Helper::Context
 
         MSGS = {
-          cancel: 'Broadcasting cancelation message for <Job id=%s state=%s>',
+          amqp_cancel: 'Broadcasting cancelation message for <Job id=%s state=%s>',
+          job_board_cancel: 'Canceling via Job Board delete for <Job id=%s state=%s>'
         }
 
         def cancel(job)
-          info :cancel, job.id, job.state
           cancel_via_job_board(job)
           cancel_via_amqp(job)
         end
@@ -19,10 +19,12 @@ module Travis
         private
 
           def cancel_via_job_board(job)
+            info :job_board_cancel, job.id, job.state
             job_board.cancel(job.id)
           end
 
           def cancel_via_amqp(job)
+            info :amqp_cancel, job.id, job.state
             context.amqp.fanout(
               'worker.commands',
               type: 'cancel_job', job_id: job.id, source: 'hub'

--- a/lib/travis/hub/service/notify_workers.rb
+++ b/lib/travis/hub/service/notify_workers.rb
@@ -19,6 +19,8 @@ module Travis
         private
 
           def cancel_via_job_board(job)
+            return if context.config.job_board.url.to_s =~ /not:set/
+
             info :job_board_cancel, job.id, job.state
             job_board.cancel(job.id)
           end

--- a/lib/travis/hub/support/job_board.rb
+++ b/lib/travis/hub/support/job_board.rb
@@ -1,0 +1,47 @@
+require 'faraday'
+
+module Travis
+  module Hub
+    module Support
+      class JobBoard < Struct.new(:config)
+        def cancel(id)
+          client.delete do |req|
+            req.url "jobs/#{id}"
+            req.params['source'] = 'hub'
+            req.headers['Travis-Site'] = site
+            req.body = nil
+          end
+        end
+
+        private
+
+          def client
+            @client ||= Faraday.new(url: url) do |c|
+              c.basic_auth(*basic_auth)
+              c.request :retry, max: 3, interval: 0.1, backoff_factor: 2
+              c.adapter :net_http
+            end
+          end
+
+          def site
+            config[:site] || raise(StandardError, 'Job Board site not set.')
+          end
+
+          def url
+            config[:url] || raise(StandardError, 'Job Board URL not set.')
+          end
+
+          def basic_auth
+            return @basic_auth if defined?(@basic_auth)
+
+            parsed = URI(url)
+            if parsed.user.nil? && parsed.password.nil?
+              raise StandardError, 'Job Board basic auth not set.'
+            end
+
+            @basic_auth = [parsed.user, parsed.password]
+          end
+      end
+    end
+  end
+end

--- a/spec/travis/hub/service/update_build_spec.rb
+++ b/spec/travis/hub/service/update_build_spec.rb
@@ -10,6 +10,10 @@ describe Travis::Hub::Service::UpdateBuild do
   before      { amqp.stubs(:fanout) }
   before      { metrics.stubs(:meter) }
   before      { events.stubs(:dispatch) }
+  before do
+    stub_request(:delete, %r{https://job-board\.travis-ci\.com/jobs/\d+\?source=hub})
+      .to_return(status: 204)
+  end
 
   describe 'create event' do
     # let(:state) { :create }

--- a/spec/travis/hub/service/update_job_spec.rb
+++ b/spec/travis/hub/service/update_job_spec.rb
@@ -7,7 +7,12 @@ describe Travis::Hub::Service::UpdateJob do
   let(:now)         { Time.now.utc }
 
   subject     { described_class.new(context, event, data) }
-  before      { amqp.stubs(:fanout) }
+
+  before do
+    amqp.stubs(:fanout)
+    stub_request(:delete, %r{https://job-board\.travis-ci\.com/jobs/\d+\?source=hub})
+      .to_return(status: 204)
+  end
 
   describe 'receive event' do
     let(:state) { :queued }


### PR DESCRIPTION
This ensures that jobs are deleted out of Job Board at cancellation time when no worker is actively processing the job.