### PR TITLE
Remove travis-rollout and enable per-user channels by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'travis-config',          git: 'https://github.com/travis-ci/travis-config'
 gem 'travis-encrypt'
 gem 'travis-lock',            git: 'https://github.com/travis-ci/travis-lock'
 gem 'travis-support',         git: 'https://github.com/travis-ci/travis-support'
-gem 'travis-rollout',         git: 'https://github.com/travis-ci/travis-rollout', branch: 'sf-refactor'
 
 gem 'rake'
 gem 'jemalloc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,13 +46,6 @@ GIT
       metriks-librato_metrics (~> 1.0)
 
 GIT
-  remote: https://github.com/travis-ci/travis-rollout
-  revision: 71cc9102dff01f95c281f99183e54b6695faa7ec
-  branch: sf-refactor
-  specs:
-    travis-rollout (0.0.1)
-
-GIT
   remote: https://github.com/travis-ci/travis-support
   revision: 113cff17fe383bb72fcfae3a97a8ce98c228342f
   specs:
@@ -225,7 +218,6 @@ DEPENDENCIES
   travis-lock!
   travis-logger!
   travis-metrics!
-  travis-rollout!
   travis-support!
   webmock
 

--- a/lib/travis/addons/handlers/pusher.rb
+++ b/lib/travis/addons/handlers/pusher.rb
@@ -2,7 +2,6 @@ require 'travis/addons/handlers/base'
 require 'travis/addons/serializer/pusher/build'
 require 'travis/addons/serializer/pusher/job'
 require 'travis/sidekiq'
-require 'travis/rollout'
 
 module Travis
   module Addons
@@ -21,12 +20,7 @@ module Travis
         end
 
         def handle
-          params = { event: event }
-          uid = "#{object.repository.owner_id}-#{object.repository.owner_type[0]}"
-          Travis::Rollout.run('user-channel', redis: Travis::Hub.context.redis, uid: uid) do
-            params[:user_ids] = user_ids
-          end
-
+          params = { event: event, user_ids: user_ids }
           Travis::Sidekiq.live(deep_clean_strings(payload), params)
         end
 


### PR DESCRIPTION
This commit removes the conditional travis-rollout code and treats it as
a new default.