### PR TITLE
Alter request retry settings for updates to logs

### DIFF
--- a/lib/travis/hub/config.rb
+++ b/lib/travis/hub/config.rb
@@ -16,7 +16,7 @@ module Travis
 
       define amqp:           { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
              database:       { adapter: 'postgresql', database: "travis_#{env}", encoding: 'unicode', min_messages: 'warning', pool: 25, reaping_frequency: 60, variables: { statement_timeout: 10000 } },
-             logs_api:       { url: 'https://travis-logs-notset.example.com:1234', token: 'notset' },
+             logs_api:       { url: 'https://travis-logs-notset.example.com:1234', token: 'notset', retries: { max: 5, interval: 3, max_interval: 60, interval_randomness: 0.5, backoff_factor: 2 } },
              job_board:      { url: 'https://not:set@job-board.travis-ci.com', site: 'org' },
              redis:          { url: 'redis://localhost:6379' },
              sidekiq:        { namespace: 'sidekiq', pool_size: 1 },

--- a/lib/travis/hub/support/logs.rb
+++ b/lib/travis/hub/support/logs.rb
@@ -33,8 +33,7 @@ module Travis
           def client
             @client ||= Faraday.new(http_options.merge(url: url)) do |c|
               c.request :authorization, :token, token
-              c.request :retry, max: 5, interval: 3, max_interval: 60,
-                                interval_randomness: 0.5, backoff_factor: 2
+              c.request :retry, retry_config
               c.response :raise_error
               c.adapter :net_http
             end
@@ -46,6 +45,10 @@ module Travis
 
           def token
             config[:token] || raise('Logs token not set.')
+          end
+
+          def retry_config
+            config[:retries]
           end
 
           def http_options

--- a/lib/travis/hub/support/logs.rb
+++ b/lib/travis/hub/support/logs.rb
@@ -33,7 +33,8 @@ module Travis
           def client
             @client ||= Faraday.new(http_options.merge(url: url)) do |c|
               c.request :authorization, :token, token
-              c.request :retry, max: 5, interval: 0.1, backoff_factor: 2
+              c.request :retry, max: 5, interval: 3, max_interval: 60,
+                                interval_randomness: 0.5, backoff_factor: 2
               c.response :raise_error
               c.adapter :net_http
             end


### PR DESCRIPTION
to (hopefully) increase resilience, ensuring logs are updated/cleared at
build restart time.