### PR TITLE
Use Sidekiq's super_fetch! method

### DIFF
--- a/lib/travis/hub/support/sidekiq.rb
+++ b/lib/travis/hub/support/sidekiq.rb
@@ -22,7 +22,7 @@ module Travis
         c.logger.formatter = Support::Sidekiq::Logging.new(config.logger || {})
 
         if pro?
-          c.reliable_fetch!
+          c.super_fetch!
           c.reliable_scheduler!
         end
       end


### PR DESCRIPTION
From commit message:

```
Sidekiq Pro introduces algorithms to work more reliably than the regular
version. Till now we use the one called `reliable_fetch!`. It's
deprecated and it will be removed in next major version and
`super_fetch!` is now recommended way.
```

More info here: https://github.com/mperham/sidekiq/wiki/Reliability