### PR TITLE
Handle cancel events via HTTP

### DIFF
--- a/lib/travis/hub/api.rb
+++ b/lib/travis/hub/api.rb
@@ -40,12 +40,13 @@ module Travis
       private
 
         EVENTS = {
-          created:  :reset,
-          received: :receive,
-          started:  :start,
-          passed:   :finish,
-          failed:   :finish,
-          errored:  :finish
+          created:   :reset,
+          received:  :receive,
+          started:   :start,
+          passed:    :finish,
+          failed:    :finish,
+          errored:   :finish,
+          cancelled: :cancel
         }
 
         def update_state


### PR DESCRIPTION
as they are also handled via AMQP and the lack of a matching event key is resulting in errors.

Best viewed with whitespace ignored 😁 https://github.com/travis-ci/travis-hub/pull/139/files?w=1