### PR TITLE
Send `updated_at` for builds and jobs with Pusher

### DIFF
--- a/lib/travis/addons/handlers/pusher.rb
+++ b/lib/travis/addons/handlers/pusher.rb
@@ -20,6 +20,10 @@ module Travis
         end
 
         def handle
+          # we need to always make sure that the data is fresh, because Active
+          # Record doesn't always refresh the updated_at column
+          object.reload
+
           params = { event: event, user_ids: user_ids }
           Travis::Sidekiq.live(deep_clean_strings(payload), params)
         end

--- a/lib/travis/addons/serializer/formats.rb
+++ b/lib/travis/addons/serializer/formats.rb
@@ -5,6 +5,10 @@ module Travis
         def format_date(date)
           date && date.strftime('%Y-%m-%dT%H:%M:%SZ')
         end
+
+        def format_date_with_ms(date)
+          date && date.strftime('%Y-%m-%dT%H:%M:%S.%3NZ')
+        end
       end
     end
   end

--- a/lib/travis/addons/serializer/pusher/build.rb
+++ b/lib/travis/addons/serializer/pusher/build.rb
@@ -91,6 +91,7 @@ module Travis
                 duration: build.duration,
                 job_ids: build.job_ids,
                 event_type: build.event_type,
+                updated_at: format_date_with_ms(build.updated_at),
 
                 # this is a legacy thing, we should think about removing it
                 commit: commit.commit,

--- a/lib/travis/addons/serializer/pusher/job.rb
+++ b/lib/travis/addons/serializer/pusher/job.rb
@@ -37,6 +37,7 @@ module Travis
                 finished_at: format_date(job.finished_at),
                 queue: job.queue,
                 allow_failure: job.allow_failure,
+                updated_at: format_date_with_ms(job.updated_at)
               }
             end
 

--- a/spec/travis/addons/serializer/pusher/build_spec.rb
+++ b/spec/travis/addons/serializer/pusher/build_spec.rb
@@ -32,7 +32,8 @@ describe Travis::Addons::Serializer::Pusher::Build do
       pull_request: false,
       pull_request_title: nil,
       pull_request_number: nil,
-      job_ids: [job.id]
+      job_ids: [job.id],
+      updated_at: build.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%3NZ')
     )
   end
 

--- a/spec/travis/addons/serializer/pusher/job_spec.rb
+++ b/spec/travis/addons/serializer/pusher/job_spec.rb
@@ -19,7 +19,8 @@ describe Travis::Addons::Serializer::Pusher::Job do
       finished_at: nil,
       state: 'created',
       queue: nil,
-      allow_failure: false
+      allow_failure: false,
+      updated_at: build.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%3NZ')
     )
   end
 


### PR DESCRIPTION
We will be treating the updated_at column as a record's version.