### PR TITLE
switch metriks gem to branch which uses hdrhistogram

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,14 @@ gem 'sidekiq-pro', source: 'https://gems.contribsys.com'
 gem 'travis-exceptions',      git: 'https://github.com/travis-ci/travis-exceptions'
 gem 'travis-logger',          git: 'https://github.com/travis-ci/travis-logger'
 gem 'travis-metrics',         git: 'https://github.com/travis-ci/travis-metrics'
-gem 'travis-instrumentation', git: 'https://github.com/travis-ci/travis-instrumentation'
 
 gem 'travis-config',          git: 'https://github.com/travis-ci/travis-config'
 gem 'travis-encrypt'
 gem 'travis-lock',            git: 'https://github.com/travis-ci/travis-lock'
 gem 'travis-support',         git: 'https://github.com/travis-ci/travis-support'
+
+gem 'metriks',                 git: 'https://github.com/travis-ci/metriks', ref: 'igor-hdr-histogram'
+gem 'metriks-librato_metrics', git: 'https://github.com/travis-ci/metriks-librato_metrics', ref: 'igor-hdr-histogram'
 
 gem 'rake'
 gem 'jemalloc'
@@ -26,7 +28,6 @@ gem 'faraday'
 
 gem 'gh'
 gem 'keen'
-gem 'metriks-librato_metrics'
 gem 'sentry-raven'
 gem 'simple_states', git: 'https://github.com/svenfuchs/simple_states'
 gem 'multi_json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,25 @@ GIT
     simple_states (2.0.1)
 
 GIT
+  remote: https://github.com/travis-ci/metriks
+  revision: 9b5a34fecebecc741417b25e43c340394aa6cc5e
+  ref: igor-hdr-histogram
+  specs:
+    metriks (0.9.9.8)
+      HDRHistogram (~> 0.1.3)
+      atomic (~> 1.0)
+      avl_tree (~> 1.2.0)
+      hitimes (~> 1.1)
+
+GIT
+  remote: https://github.com/travis-ci/metriks-librato_metrics
+  revision: 7ec1c97f4f6f783d2a04c7922baac98a9fbbba25
+  ref: igor-hdr-histogram
+  specs:
+    metriks-librato_metrics (1.0.6)
+      metriks (>= 0.9.9.6)
+
+GIT
   remote: https://github.com/travis-ci/travis-config
   revision: a64596623f8f8ee70838a4dc4d7803906a049733
   specs:
@@ -17,14 +36,6 @@ GIT
   specs:
     travis-exceptions (0.0.2)
       sentry-raven
-
-GIT
-  remote: https://github.com/travis-ci/travis-instrumentation
-  revision: b068fa1b54752a829ceb35532bf5dda85d947f01
-  specs:
-    travis-instrumentation (0.0.1)
-      activesupport (~> 4)
-      travis-metrics (~> 0)
 
 GIT
   remote: https://github.com/travis-ci/travis-lock
@@ -40,9 +51,9 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/travis-metrics
-  revision: 37eac93bd1e9bd949a9842f28154c335ebeda42a
+  revision: 4bdac5f6d71425ed7ab1f775535db47e84fd141f
   specs:
-    travis-metrics (0.0.1)
+    travis-metrics (2.0.0)
       metriks-librato_metrics (~> 1.0)
 
 GIT
@@ -55,6 +66,7 @@ GEM
   remote: https://rubygems.org/
   remote: https://gems.contribsys.com/
   specs:
+    HDRHistogram (0.1.3)
     activemodel (4.2.8)
       activesupport (= 4.2.8)
       builder (~> 3.1)
@@ -100,19 +112,13 @@ GEM
       net-http-pipeline
     hashdiff (0.3.0)
     hashr (2.0.0)
-    hitimes (1.2.4)
+    hitimes (1.2.6)
     i18n (0.8.1)
     jemalloc (1.0.1)
     jwt (1.5.4)
     keen (0.7.8)
       multi_json (~> 1.0)
     metaclass (0.0.4)
-    metriks (0.9.9.7)
-      atomic (~> 1.0)
-      avl_tree (~> 1.2.0)
-      hitimes (~> 1.1)
-    metriks-librato_metrics (1.0.5)
-      metriks (>= 0.9.9.6)
     minitest (5.10.2)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
@@ -195,7 +201,8 @@ DEPENDENCIES
   jemalloc
   jwt
   keen
-  metriks-librato_metrics
+  metriks!
+  metriks-librato_metrics!
   mocha
   multi_json
   pg
@@ -214,7 +221,6 @@ DEPENDENCIES
   travis-config!
   travis-encrypt
   travis-exceptions!
-  travis-instrumentation!
   travis-lock!
   travis-logger!
   travis-metrics!
@@ -225,4 +231,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/lib/travis/hub/event/metrics.rb
+++ b/lib/travis/hub/event/metrics.rb
@@ -44,6 +44,7 @@ module Travis
 
           def timer(events, duration)
             events.each do |event|
+              event = "v1.#{event}"
               Metriks.timer(event).update(duration)
             end
           end

--- a/lib/travis/hub/event/metrics.rb
+++ b/lib/travis/hub/event/metrics.rb
@@ -44,7 +44,6 @@ module Travis
 
           def timer(events, duration)
             events.each do |event|
-              event = "v1.#{event}"
               Metriks.timer(event).update(duration)
             end
           end

--- a/lib/travis/hub/handler.rb
+++ b/lib/travis/hub/handler.rb
@@ -70,10 +70,10 @@ module Travis
         def time
           started_at = Time.now
           yield.tap do
-            options = { started_at: started_at, finished_at: Time.now }
-            meter("hub.handle", options)
-            meter("hub.handle.#{type}", options)
-            meter("hub.handle.#{type}.#{event}", options)
+            duration = Time.now - started_at
+            timer("hub.handle", duration)
+            timer("hub.handle.#{type}", duration)
+            timer("hub.handle.#{type}.#{event}", duration)
           end
         end
 

--- a/lib/travis/hub/helper/context.rb
+++ b/lib/travis/hub/helper/context.rb
@@ -39,8 +39,12 @@ module Travis
           Exceptions.handle(*args)
         end
 
-        def meter(*args, &block)
-          metrics.meter(*args, &block)
+        def meter(key)
+          metrics.meter(key)
+        end
+
+        def timer(key, duration)
+          Metriks.timer(key).update(duration)
         end
       end
     end

--- a/lib/travis/hub/helper/context.rb
+++ b/lib/travis/hub/helper/context.rb
@@ -44,6 +44,7 @@ module Travis
         end
 
         def timer(key, duration)
+          key = "v1.#{key}"
           Metriks.timer(key).update(duration)
         end
       end

--- a/lib/travis/hub/helper/context.rb
+++ b/lib/travis/hub/helper/context.rb
@@ -44,7 +44,6 @@ module Travis
         end
 
         def timer(key, duration)
-          key = "v1.#{key}"
           Metriks.timer(key).update(duration)
         end
       end

--- a/lib/travis/hub/support/reroute.rb
+++ b/lib/travis/hub/support/reroute.rb
@@ -74,8 +74,7 @@ module Travis
 
         def percent
           percent = ENV['REROUTE_PERCENT'] || context.redis.get(:"#{name}_percent") || -1
-          # metrics.gauge('hub.reroute.percent', percent.to_i) # TODO
-          Metriks.gauge('v1.hub.reroute.percent').set(percent.to_i)
+          Metriks.gauge('hub.reroute.percent').set(percent.to_i)
         rescue => e
           Raven.capture_exception(e)
           percent ? percent.to_i : -1

--- a/lib/travis/instrumentation.rb
+++ b/lib/travis/instrumentation.rb
@@ -23,7 +23,6 @@ module Travis
       def meter(event, options = {})
         return if options[:level] == :debug
 
-        event = "v1.#{event}"
         started_at, finished_at = options[:started_at], options[:finished_at]
 
         if finished_at

--- a/lib/travis/instrumentation.rb
+++ b/lib/travis/instrumentation.rb
@@ -1,0 +1,80 @@
+require 'active_support/notifications'
+require 'active_support/core_ext/string/inflections'
+require 'securerandom' # wat
+require 'travis/metrics'
+require 'travis/instrumentation/instrument'
+require 'travis/instrumentation/publisher/log'
+require 'travis/instrumentation/publisher/memory'
+
+module Travis
+  module Instrumentation
+    class << self
+      attr_reader :publishers
+
+      def setup(logger)
+        @publishers = []
+        publishers << Publisher::Log.new(logger)
+      end
+
+      def publish(event)
+        publishers && publishers.each { |publisher| publisher.publish(event) }
+      end
+
+      def meter(event, options = {})
+        return if options[:level] == :debug
+
+        event = "v1.#{event}"
+        started_at, finished_at = options[:started_at], options[:finished_at]
+
+        if finished_at
+          Metriks.timer(event).update(finished_at - started_at)
+        else
+          Metriks.meter(event).mark
+        end
+      end
+    end
+
+    def instrumentation_key=(instrumentation_key)
+      @instrumentation_key = instrumentation_key
+    end
+
+    def instrumentation_key
+      @instrumentation_key ||= name.underscore.gsub('/', '.')
+    end
+
+    def instrument(name, options = {})
+      wrapped = "#{name}_without_instrumentation"
+      alias_method(wrapped, name)
+      remove_method(name)
+      private(wrapped)
+      class_eval instrumentation_template(name, options[:scope], wrapped, options[:level] || :info, options[:on])
+    end
+
+    private
+
+      def instrumentation_template(name, scope, wrapped, level, status)
+        status ||= [:received, :completed, :failed]
+        status   = Array(status) unless status.is_a?(Array)
+
+        options  = 'target: self, args: args, started_at: started_at, level: ' + level.inspect
+        meter    = 'Travis::Instrumentation.meter "#{event}:%s", ' + options
+        publish  = 'ActiveSupport::Notifications.publish "#{event}:%s", ' + options
+
+        <<-RUBY
+          def #{name}(*args, &block)
+            started_at = Time.now.to_f
+            event = self.class.instrumentation_key.dup #{"<< '.' << #{scope}" if scope} << ".#{name}"
+            #{publish % 'received' if status.include?(:received)}
+            result = #{wrapped}(*args, &block)
+            #{"#{meter   % 'completed'}, finished_at: Time.now.to_f, result: result" if status.include?(:completed)}
+            #{"#{publish % 'completed'}, finished_at: Time.now.to_f, result: result" if status.include?(:completed)}
+            result
+          rescue Exception => e
+            #{"#{meter   % 'failed'}, exception: [e.class.name, e.message]" if status.include?(:failed)}
+            #{"#{publish % 'failed'}, exception: [e.class.name, e.message]" if status.include?(:failed)}
+            raise
+          end
+        RUBY
+      end
+  end
+end

--- a/lib/travis/instrumentation/instrument.rb
+++ b/lib/travis/instrumentation/instrument.rb
@@ -1,0 +1,66 @@
+# TODO
+#
+# * Stop using ActiveSupport, just dispatch stuff
+# * Use Module#prepend
+
+module Travis
+  module Instrumentation
+    class Instrument
+      class << self
+        def attach_to(const)
+          statuses = %w(received completed failed)
+          instrumented_methods(const).product(statuses).each do |method, status|
+            ActiveSupport::Notifications.subscribe(/^#{const.instrumentation_key}(\..+)?.#{method}:#{status}/) do |message, args|
+              publish(message, method, status, args)
+            end
+          end
+        end
+
+        def instrumented_methods(const)
+          consts = ancestors.select { |const| (const.name || '')[0..5] == 'Travis' }
+          methods = consts.map { |const| const.public_instance_methods(false) }.flatten.uniq
+          methods = methods.map { |method| method.to_s =~ /^(.*)_(received|completed|failed)$/ && $1 }
+          methods.compact.uniq
+        end
+
+        def publish(event, method, status, payload)
+          instrument = new(event, method, status, payload)
+          callback = :"#{method}_#{status}"
+          instrument.respond_to?(callback) ? instrument.send(callback) : instrument.publish
+        end
+      end
+
+      attr_reader :target, :method, :status, :result, :exception, :meta
+
+      def initialize(event, method, status, payload)
+        @method, @status = method, status
+        @target, @result, @exception = payload.values_at(:target, :result, :exception)
+        started_at, finished_at = payload.values_at(:started_at, :finished_at)
+        @meta = compact(
+          event:       event,
+          started_at:  started_at,
+          finished_at: finished_at,
+          duration:    finished_at ? finished_at - started_at : nil,
+        )
+      end
+
+      def publish(data = {})
+        message = "#{target.class.name}##{method}:#{status} #{data.delete(:msg)}".strip
+        payload = meta.merge(message: message, data: data)
+        payload[:result] = data.delete(:result) if data.key?(:result)
+        payload[:exception] = exception if exception
+        Instrumentation.publish(payload)
+      end
+
+      private
+
+        def to_pairs(hash)
+          hash.map { |key, value| [key, value].join('=') }.join(' ')
+        end
+
+        def compact(hash)
+          hash.reject { |key, _| key.nil? }
+        end
+    end
+  end
+end

--- a/lib/travis/instrumentation/publisher/log.rb
+++ b/lib/travis/instrumentation/publisher/log.rb
@@ -1,0 +1,32 @@
+module Travis
+  module Instrumentation
+    module Publisher
+      class Log
+        attr_reader :logger
+
+        def initialize(logger = nil)
+          @logger = logger
+        end
+
+        def publish(event)
+          level = event.key?(:exception) ? :error : :info
+          message = event[:message]
+          message = "#{message} (#{'%.5f' % event[:duration]}s)" if event[:duration]
+          log(level, message)
+
+          if level == :error || logger.level == ::Logger::DEBUG
+            event.each do |key, value|
+              next if key == :message
+              level = event.key?(:exception) ? :error : :debug
+              log(level, "  #{key}: #{value.inspect}")
+            end
+          end
+        end
+
+        def log(level, msg)
+          logger.send(level, msg)
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/instrumentation/publisher/memory.rb
+++ b/lib/travis/instrumentation/publisher/memory.rb
@@ -1,0 +1,15 @@
+module Travis
+  module Instrumentation
+    module Publisher
+      class Memory
+        def publish(event)
+          events << event
+        end
+
+        def events
+          @events ||= []
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/instrumentation/version.rb
+++ b/lib/travis/instrumentation/version.rb
@@ -1,0 +1,5 @@
+module Travis
+  module Instrumentation
+    VERSION = "0.0.1"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,7 @@ RSpec.configure do |c|
   c.before do
     Travis::Event.instance_variable_set(:@subscriptions, nil)
     Time.stubs(:now).returns(NOW)
+    Time.stubs(:new).returns(NOW)
   end
 end
 

--- a/spec/support/context.rb
+++ b/spec/support/context.rb
@@ -7,7 +7,13 @@ module Support
     included do
       let(:stdout)  { StringIO.new }
       let(:logger)  { Travis::Logger.new(stdout) }
-      let(:context) { Travis::Hub::Context.new(logger: logger) }
+      let(:metrics) { Travis::Metrics.setup({}, logger) }
+      let(:context) {
+        Travis::Hub::Context.new(
+          logger: logger,
+          metrics: metrics
+        )
+      }
       before        { Travis::Hub.context = context }
       before        { Travis::Instrumentation.setup(context.logger) }
     end

--- a/spec/travis/hub/service/update_build_spec.rb
+++ b/spec/travis/hub/service/update_build_spec.rb
@@ -3,12 +3,11 @@ describe Travis::Hub::Service::UpdateBuild do
   let(:build) { FactoryGirl.create(:build, { jobs: [job], received_at: now - 10 }.merge(state ? { state: state } : {})) }
   let(:job)   { FactoryGirl.create(:job, state ? { state: state } : {}) }
   let(:amqp)  { Travis::Amqp.any_instance }
-  let(:metrics) { Travis::Metrics }
   let(:events)  { Travis::Event }
 
   subject     { described_class.new(context, event, data) }
   before      { amqp.stubs(:fanout) }
-  before      { metrics.stubs(:meter) }
+  before      { context.metrics.stubs(:meter) }
   before      { events.stubs(:dispatch) }
   before do
     stub_request(:delete, %r{https://job-board\.travis-ci\.com/jobs/\d+\?source=hub})
@@ -174,7 +173,7 @@ describe Travis::Hub::Service::UpdateBuild do
     end
 
     it 'meters the event' do
-      metrics.expects(:meter).with('hub.job.auto_cancel')
+      context.metrics.expects(:meter).with('hub.job.auto_cancel')
       subject.run
     end
   end


### PR DESCRIPTION
due to an incompatibility with travis-instrumentation (it depends on an old version of travis-metrics), that gem has been vendored and patched to work with the latest versions of travis-metrics and metriks.

there is a hilarious story behind the Time.new patch, by stubbing Time.now and not Time.new, metriks ended up computing a 222 million second time difference (~7 years, from 2011 until 2018), and was running 44 million computations to account for the interval, which ended up slowing the test suite down _a lot_!

for context on what the hdrhistogram change in metriks does, see the pull request referenced below.

refs travis-ci/travis-gatekeeper#264