### PR TITLE
Fix always nil SSL config block in Enterprise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,28 +27,28 @@ script:
   - bundle exec rspec
 
 
-jobs:
-  include:
-    - stage: "testing time"
-    - stage: ":ship: it to Quay.io"
-      sudo: required
-      dist: trusty
-      ruby:
-      services:
-      addons:
-      before_install: skip
-      install: skip
-      before_script:
-        - curl -L https://github.com/docker/compose/releases/download/1.13.0/docker-compose-`uname -s`-`uname -m` > ./docker-compose
-        - sudo mv ./docker-compose /usr/local/bin/docker-compose
-        - sudo chmod +x /usr/local/bin/docker-compose
-      script: ./script/docker-build-and-push
+# jobs:
+#   include:
+#     - stage: "testing time"
+#     - stage: ":ship: it to Quay.io"
+#       sudo: required
+#       dist: trusty
+#       ruby:
+#       services:
+#       addons:
+#       before_install: skip
+#       install: skip
+#       before_script:
+#         - curl -L https://github.com/docker/compose/releases/download/1.13.0/docker-compose-`uname -s`-`uname -m` > ./docker-compose
+#         - sudo mv ./docker-compose /usr/local/bin/docker-compose
+#         - sudo chmod +x /usr/local/bin/docker-compose
+#       script: ./script/docker-build-and-push
 
-    - stage: "trigger automated build on Docker Hub"
-      ruby:
-      services:
-      addons:
-      before_install: skip
-      before_script: skip
-      install: skip
-      script: script/send-docker-hub-trigger
+#     - stage: "trigger automated build on Docker Hub"
+#       ruby:
+#       services:
+#       addons:
+#       before_install: skip
+#       before_script: skip
+#       install: skip
+#       script: script/send-docker-hub-trigger

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ script:
   - bundle exec rspec
 
 
-# jobs:
-#   include:
+jobs:
+  include:
 #     - stage: "testing time"
 #     - stage: ":ship: it to Quay.io"
 #       sudo: required
@@ -44,11 +44,11 @@ script:
 #         - sudo chmod +x /usr/local/bin/docker-compose
 #       script: ./script/docker-build-and-push
 
-#     - stage: "trigger automated build on Docker Hub"
-#       ruby:
-#       services:
-#       addons:
-#       before_install: skip
-#       before_script: skip
-#       install: skip
-#       script: script/send-docker-hub-trigger
+    - stage: "trigger automated build on Docker Hub"
+      ruby:
+      services:
+      addons:
+      before_install: skip
+      before_script: skip
+      install: skip
+      script: script/send-docker-hub-trigger

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,26 +29,26 @@ script:
 
 jobs:
   include:
-#     - stage: "testing time"
-#     - stage: ":ship: it to Quay.io"
-#       sudo: required
-#       dist: trusty
-#       ruby:
-#       services:
-#       addons:
-#       before_install: skip
-#       install: skip
-#       before_script:
-#         - curl -L https://github.com/docker/compose/releases/download/1.13.0/docker-compose-`uname -s`-`uname -m` > ./docker-compose
-#         - sudo mv ./docker-compose /usr/local/bin/docker-compose
-#         - sudo chmod +x /usr/local/bin/docker-compose
-#       script: ./script/docker-build-and-push
+    - stage: "testing time"
+    - stage: ":ship: it to Quay.io"
+      sudo: required
+      dist: trusty
+      ruby:
+      services:
+      addons:
+      before_install: echo "skipping"
+      install: echo "skipping"
+      before_script:
+        - curl -L https://github.com/docker/compose/releases/download/1.13.0/docker-compose-`uname -s`-`uname -m` > ./docker-compose
+        - sudo mv ./docker-compose /usr/local/bin/docker-compose
+        - sudo chmod +x /usr/local/bin/docker-compose
+      script: ./script/docker-build-and-push
 
     - stage: "trigger automated build on Docker Hub"
       ruby:
       services:
       addons:
-      before_install: skip
-      before_script: skip
-      install: skip
+      before_install: echo "skipping"
+      before_script: echo "skipping"
+      install: echo "skipping"
       script: script/send-docker-hub-trigger

--- a/lib/travis/hub/support/logs.rb
+++ b/lib/travis/hub/support/logs.rb
@@ -53,7 +53,7 @@ module Travis
 
           def http_options
             if config.ssl
-              { ssl: config.ssl.compact.to_h }
+              { ssl: config.ssl.to_h.compact }
             else
               {}
             end

--- a/lib/travis/hub/support/logs.rb
+++ b/lib/travis/hub/support/logs.rb
@@ -53,7 +53,7 @@ module Travis
 
           def http_options
             if config.ssl
-              { ssl: config.ssl.to_h.compact }
+              { ssl: config.ssl.to_h }
             else
               {}
             end


### PR DESCRIPTION
From https://github.com/travis-ci/travis-api/pull/652 

> Seeing an issue where API can't talk to the logs API when using a self signed cert. The SSL config fixes this but due to calling compact on Travis.config.ssl instead of Travis.config.ssl.to_h (as travis config objects are no longer a subclass of Hash) it will always be nil as it's looking for a config key called compact and there is none.

But this time here in Hub. 