### PR TITLE
allow cancellation to be disabled temporarily

### DIFF
--- a/lib/travis/hub/service/update_build.rb
+++ b/lib/travis/hub/service/update_build.rb
@@ -38,6 +38,10 @@ module Travis
           end
 
           def update_jobs
+            if ENV['CANCELLATION_DISABLED'] == 'true' && :cancel == event
+              raise 'cancellation has been disabled'
+            end
+
             build.jobs.each do |job|
               auto_cancel(job) if event == :cancel && auto_cancel?
               job.reload.send(:"#{event}!", attrs)

--- a/lib/travis/hub/service/update_job.rb
+++ b/lib/travis/hub/service/update_job.rb
@@ -48,6 +48,11 @@ module Travis
 
           def update_job
             return error_job if event == :reset && resets.limited? && !job.finished?
+
+            if ENV['CANCELLATION_DISABLED'] == 'true' && (event == :cancel || recancel?)
+              raise 'cancellation has been disabled'
+            end
+
             return recancel if recancel?
             return skipped if skip_canceled?
             return skipped unless job.reload.send(:"#{event}!", attrs)


### PR DESCRIPTION
in order to verify the impact that cancellations have on our rabbitmq
cpu usage, we are considering turning off cancellations for a short
period of time.

our rabbitmq cancellations have a very wide fan-out, and we want to
make sure that is not adversely affecting our rabbit instance.

when we error out these cancellations, they should be retried by
sidekiq at a later time (and periodically). this way, once
cancellations are re-enabled, we should automatically re-process the
skipped cancellations.

there will still be some user impact, but it will be in form of a
cancellation delay, as opposed to cancellation not working at all.