### PR TITLE
Use global config not build config for SSL settings

### DIFF
--- a/lib/travis/hub/support/logs.rb
+++ b/lib/travis/hub/support/logs.rb
@@ -52,8 +52,8 @@ module Travis
           end
 
           def http_options
-            if config.ssl
-              { ssl: config.ssl.to_h }
+            if Travis::Hub.context.config.ssl
+              { ssl: Travis::Hub.context.config.ssl.to_h }
             else
               {}
             end


### PR DESCRIPTION
`config` in this spot is referring to the the build it seems. As a result the connection is made without the SSL settings set in the global config/travis.yml so logs can fail due to SSL problems when self signed certs are used. 