### PR TITLE
[Enterprise Backport] Use global config not build config for SSL settings #148

### DIFF
--- a/lib/travis/hub/support/logs.rb
+++ b/lib/travis/hub/support/logs.rb
@@ -52,8 +52,8 @@ module Travis
           end
 
           def http_options
-            if config.ssl
-              { ssl: config.ssl.to_h }
+            if Travis::Hub.context.config.ssl
+              { ssl: Travis::Hub.context.config.ssl.to_h }
             else
               {}
             end


### PR DESCRIPTION
Backport of #148 
