### PR TITLE
delete DATABASE_URL from ENV in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 ENV['ENV'] = 'test'
+ENV.delete('DATABASE_URL')
 
 JWT_RSA_PRIVATE_KEY = <<KEY
 -----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
extra safety net for not accidentally running specs against a remote database