### PR TITLE
Send site to honeycomb

### DIFF
--- a/lib/travis/hub/context.rb
+++ b/lib/travis/hub/context.rb
@@ -35,6 +35,7 @@ module Travis
 
         Travis::Honeycomb::Context.add_permanent('app', 'hub')
         Travis::Honeycomb::Context.add_permanent('dyno', ENV['DYNO'])
+        Travis::Honeycomb::Context.add_permanent('site', ENV['TRAVIS_SITE'])
         Travis::Honeycomb.setup(logger)
 
         if ENV['QUERY_COMMENTS_ENABLED'] == 'true'


### PR DESCRIPTION
In order to get a more insight into the data hub sends to honeycomb, we should be able to filter by site (`org` or `com`) as well.

Since other apps are already using `TRAVIS_SITE` to determine this, I've added it as a config option to hub as well.