### PR TITLE
Only email the build creator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
     pg (0.19.0)
-    puma (3.6.0)
+    puma (3.11.4)
     rack (1.6.10)
     rack-protection (1.5.5)
       rack

--- a/lib/travis/addons/handlers/email.rb
+++ b/lib/travis/addons/handlers/email.rb
@@ -28,8 +28,6 @@ module Travis
         private
 
           def creator
-            sender = object.sender
-
             unless sender.is_a?(User)
               warn "no recipient found: build creator was not a user"
               return
@@ -40,7 +38,7 @@ module Travis
               return
             end
 
-            unless object.permissions.where(user_id: sender.id).exists?
+            unless permissions?
               warn "no recipient found: build creator (#{sender.login}) does not have permissions on this repository"
               return
             end
@@ -51,6 +49,14 @@ module Travis
             end
 
             sender.email
+          end
+
+          def sender
+            object.sender
+          end
+
+          def permissions?
+            object.repository.permissions.where(user_id: object.sender.id).exists?
           end
 
           def broadcasts

--- a/lib/travis/addons/handlers/email.rb
+++ b/lib/travis/addons/handlers/email.rb
@@ -29,28 +29,33 @@ module Travis
 
           def creator
             unless sender.is_a?(User)
-              warn "no recipient found: build creator was not a user"
+              no_recipient_warning "build creator was not a user"
               return
             end
 
             unless sender.first_logged_in_at?
-              warn "no recipient found: build creator (#{sender.login}) has not signed up"
+              no_recipient_warning "build creator (#{sender.login}) has not signed up"
               return
             end
 
             unless permissions?
-              warn "no recipient found: build creator (#{sender.login}) does not have permissions on this repository"
+              no_recipient_warning "build creator (#{sender.login}) does not have permissions on this repository"
               return
             end
 
             unless sender.email?
-              warn "no recipient found: build creator (#{sender.login}) do not have an email in the system"
+              no_recipient_warning "build creator (#{sender.login}) do not have an email in the system"
               return
             end
 
             sender.email
           end
 
+          def no_recipient_warning(desc)
+            msg = "#{self.class.to_s} build=#{object.id} status=no_recipient message=\"#{desc}\""
+            Addons.logger.warn(msg)
+          end
+          
           def sender
             object.sender
           end

--- a/lib/travis/addons/handlers/email.rb
+++ b/lib/travis/addons/handlers/email.rb
@@ -31,17 +31,22 @@ module Travis
             sender = object.sender
 
             unless sender.is_a?(User)
-              warn "no recipient found: build event creator was not a user"
+              warn "no recipient found: build creator was not a user"
               return
             end
 
             unless sender.first_logged_in_at?
-              warn "no recipient found: build event creator (#{sender.login}) has not signed up"
+              warn "no recipient found: build creator (#{sender.login}) has not signed up"
+              return
+            end
+
+            unless object.permissions.where(user_id: sender.id).exists?
+              warn "no recipient found: build creator (#{sender.login}) does not have permissions on this repository"
               return
             end
 
             unless sender.email?
-              warn "no recipient found: build event creator (#{sender.login}) do not have an email in the system"
+              warn "no recipient found: build creator (#{sender.login}) do not have an email in the system"
               return
             end
 

--- a/lib/travis/hub/model/build.rb
+++ b/lib/travis/hub/model/build.rb
@@ -23,6 +23,7 @@ class Build < ActiveRecord::Base
   belongs_to :repository
   belongs_to :owner, polymorphic: true
   belongs_to :config, foreign_key: :config_id, class_name: BuildConfig
+  belongs_to :sender, polymorphic: true
   has_many   :jobs, -> { order(:id) }, as: :source
   has_many   :stages, -> { order(:id) }
 

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -1,7 +1,7 @@
 describe Travis::Addons::Handlers::Email do
   let(:handler) { described_class.new('build:finished', id: build.id) }
   let(:repo)    { FactoryGirl.create(:repository) }
-  let(:build)   { FactoryGirl.create(:build, repository: repo, commit: commit, config: { notifications: config }) }
+  let(:build)   { FactoryGirl.create(:build, repository: repo, config: { notifications: config }) }
   let(:config)  { { email: address } }
   let(:address) { 'me@email.com' }
 

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -67,7 +67,7 @@ describe Travis::Addons::Handlers::Email do
   end
 
   describe '#recipients' do
-    let(:user)    { FactoryGirl.create(:user, first_logged_in_at: Time.now, email: "josh@travis-ci.com") }
+    let(:user)    { FactoryGirl.create(:user, login: 'joshk', first_logged_in_at: Time.now, email: "josh@travis-ci.com") }
     let(:address) { 'me@email.com' }
     let(:other)   { 'other@email.com' }
 

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -75,6 +75,7 @@ describe Travis::Addons::Handlers::Email do
       let(:config)  { { email: true } }
       before do
         build.sender = user
+        build.repository.permissions.create(user_id: user.id, admin: true, push: true, pull: true)
         build.save
       end
 
@@ -101,6 +102,12 @@ describe Travis::Addons::Handlers::Email do
           user.email = nil
           user.save
         end
+
+        it { expect(handler.recipients.sort).to eql [nil] }
+      end
+
+      context 'when creator no longer has any permissions on the repo' do
+        before { build.repository.permissions.clear }
 
         it { expect(handler.recipients.sort).to eql [nil] }
       end

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -66,7 +66,7 @@ describe Travis::Addons::Handlers::Email do
     end
   end
 
-  describe 'recipients' do
+  describe '#recipients' do
     let(:user)    { FactoryGirl.create(:user, first_logged_in_at: Time.now, email: "josh@travis-ci.com") }
     let(:address) { 'me@email.com' }
     let(:other)   { 'other@email.com' }
@@ -78,31 +78,35 @@ describe Travis::Addons::Handlers::Email do
         build.save
       end
 
-      describe 'creator is not a user' do
-        before { build.sender = nil }
-        it 'returns no email address' do
-          expect(handler.recipients.sort).to eql [nil]
+      context 'when creator is not a user' do
+        before do 
+          build.sender = nil
+          build.save
         end
+        
+        it { expect(handler.recipients.sort).to eql [nil] }
       end
 
-      describe 'creator has not signed in' do
-        before { user.first_logged_in_at = nil }
-        it 'returns no email address' do
-          expect(handler.recipients.sort).to eql [nil]
+      context 'when creator has not signed in' do
+        before do
+          user.first_logged_in_at = nil
+          user.save
         end
+
+        it { expect(handler.recipients.sort).to eql [nil] }
       end
 
-      describe 'creator does not have an email address in the system' do
-        before { user.email = nil }
-        it 'returns no email address' do
-          expect(handler.recipients.sort).to eql [nil]
+      context 'when creator does not have an email address in the system' do
+        before do
+          user.email = nil
+          user.save
         end
+
+        it { expect(handler.recipients.sort).to eql [nil] }
       end
 
-      describe 'creator has a email address in the system' do
-        it 'returns the creators email address' do
-          expect(handler.recipients.sort).to eql [user.email]
-        end
+      context 'creator has a email address in the system' do
+        it { expect(handler.recipients.sort).to eql [user.email] }
       end
     end
 

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -73,7 +73,10 @@ describe Travis::Addons::Handlers::Email do
 
     describe 'no addresses given in config' do
       let(:config)  { { email: true } }
-      before { build.sender = user }
+      before do
+        build.sender = user
+        build.save
+      end
 
       describe 'creator is not a user' do
         before { build.sender = nil }
@@ -97,7 +100,6 @@ describe Travis::Addons::Handlers::Email do
       end
 
       describe 'creator has a email address in the system' do
-        before { user.reload }
         it 'returns the creators email address' do
           expect(handler.recipients.sort).to eql [user.email]
         end

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -78,25 +78,26 @@ describe Travis::Addons::Handlers::Email do
       describe 'creator is not a user' do
         before { build.sender = nil }
         it 'returns no email address' do
-          expect(handler.recipients.sort).to eql nil
+          expect(handler.recipients.sort).to eql [nil]
         end
       end
 
       describe 'creator has not signed in' do
         before { user.first_logged_in_at = nil }
         it 'returns no email address' do
-          expect(handler.recipients.sort).to eql nil
+          expect(handler.recipients.sort).to eql [nil]
         end
       end
 
       describe 'creator does not have an email address in the system' do
         before { user.email = nil }
         it 'returns no email address' do
-          expect(handler.recipients.sort).to eql nil
+          expect(handler.recipients.sort).to eql [nil]
         end
       end
 
       describe 'creator has a email address in the system' do
+        before { user.reload }
         it 'returns the creators email address' do
           expect(handler.recipients.sort).to eql [user.email]
         end


### PR DESCRIPTION
Currently we email people based on the git commit information.

This is a very flakey way to know who to email, and what email address to use.

Low and behold, we also track who created the build, so why not only email the creator? I mean, they did create the build, so it seems like the smart thing to do?