### PR TITLE
Skip build emails for users with "no emails" global preference

### DIFF
--- a/lib/travis/addons/handlers/email.rb
+++ b/lib/travis/addons/handlers/email.rb
@@ -31,6 +31,7 @@ module Travis
             emails = [commit.author_email, commit.committer_email]
             user_ids = object.repository.permissions.pluck(:user_id)
             user_ids -= object.repository.email_unsubscribes.pluck(:user_id)
+            user_ids -= User.where(id: user_ids).with_preference(:build_emails, false).pluck(:id)
             ::Email.where(email: emails, user_id: user_ids).pluck(:email).uniq
           end
 

--- a/lib/travis/addons/model/user.rb
+++ b/lib/travis/addons/model/user.rb
@@ -11,6 +11,10 @@ class User < ActiveRecord::Base
     def with_permissions(permissions)
       where(:permissions => permissions).includes(:permissions)
     end
+
+    def with_preference(preference, value)
+      where(["preferences->>? = ?", preference.to_s, value.to_s])
+    end
   end
 
   has_many :permissions

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -94,9 +94,15 @@ describe Travis::Addons::Handlers::Email do
         expect(handler.recipients).to eql [committer]
       end
 
-      it 'does not return users who have unsubscribed' do
+      it 'does not return users who have unsubscribed from this repo' do
         Email.create(user: user, email: committer)
         EmailUnsubscribe.create(user: user, repository: repo)
+        expect(handler.recipients).to be_empty
+      end
+
+      it 'does not return users who have the no emails global preference' do
+        user.update_attributes!(preferences: JSON.dump(build_emails: false))
+        Email.create(user: user, email: committer)
         expect(handler.recipients).to be_empty
       end
     end


### PR DESCRIPTION
Because we're only reading the preferences I decided that we don't really need all the json-pair/json-slice/json-sync infrastructure we use in travis-api, but feel free to convince me of the opposite.

It works but it's WIP because:

1. Querying JSON this way requires Postgres > 9.3 or 9.5 depending on where I'm reading, so I want to have a detailed look at whether this works in all our supported versions. The alternative would be `JSON.parse()`ing and `Enumerable#select {...}`ing it which wouldn't be a huge deal, it's always a very small set of records
2. I'm trying to refactor that method to a single query which should be totally possible, but only worth it if it simplifies the code, as the performance is fine with the multiple queries anyway (see 1)