### PR TITLE
Send `configured` flag with build_finished email job

### DIFF
--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -63,8 +63,20 @@ describe Travis::Addons::Handlers::Email do
     let(:recipient)  { 'me@email.com' }
 
     it 'enqueues a task' do
-      handler.expects(:run_task).with(:email, is_a(Hash), recipients: [recipient], broadcasts: [{ message: 'message', category: 'announcement'}])
+      handler.expects(:run_task).with(:email, is_a(Hash), recipients: [recipient], broadcasts: [{ message: 'message', category: 'announcement'}], configured: true)
       handler.handle
+    end
+
+    context 'without configuring recipients' do
+      before do
+        config[:email] = true
+        handler.stubs(subscribed_emails: [recipient])
+      end
+
+      it 'enqueues a task' do
+        handler.expects(:run_task).with(:email, is_a(Hash), recipients: [recipient], broadcasts: [{ message: 'message', category: 'announcement'}], configured: false)
+        handler.handle
+      end
     end
   end
 


### PR DESCRIPTION
It tells whether the email is configured or it resorted to the subscriptions settings. Then the template could use it to display help on how to change it instead of the unsubscribe link (which won't do anything).