### PR TITLE
Global unsubscribe takes precedence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,4 +52,5 @@ group :test do
   gem 'webmock'
   gem 'sinatra-contrib'
   gem 'rack-test'
+  gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
     bunny (2.9.2)
       amq-protocol (~> 2.3.0)
     coder (0.4.0)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     crack (0.4.3)
@@ -138,6 +139,7 @@ GEM
     libhoney (1.4.1)
       http (~> 2.0)
     metaclass (0.0.4)
+    method_source (0.9.0)
     minitest (5.11.3)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
@@ -146,6 +148,9 @@ GEM
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
     pg (0.19.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     puma (3.6.0)
     rack (1.6.10)
     rack-protection (1.5.5)
@@ -231,6 +236,7 @@ DEPENDENCIES
   mocha
   multi_json
   pg
+  pry
   puma
   rack-ssl
   rack-test

--- a/lib/travis/addons/handlers/email.rb
+++ b/lib/travis/addons/handlers/email.rb
@@ -20,18 +20,22 @@ module Travis
 
         def recipients
           @recipients ||= begin
-            recipients = config.values(:email, :recipients)
-            recipients.try(:any?) ? recipients : default_recipients
+            emails = configured_emails || default_emails
+            emails - ::Email.joins(:user).where(email: emails).merge(User.with_preference(:build_emails, false)).pluck(:email).uniq
           end
         end
 
         private
 
-          def default_recipients
+          def configured_emails
+            emails = config.values(:email, :recipients)
+            emails.try(:any?) && emails
+          end
+
+          def default_emails
             emails = [commit.author_email, commit.committer_email]
             user_ids = object.repository.permissions.pluck(:user_id)
             user_ids -= object.repository.email_unsubscribes.pluck(:user_id)
-            user_ids -= User.where(id: user_ids).with_preference(:build_emails, false).pluck(:id)
             ::Email.where(email: emails, user_id: user_ids).pluck(:email).uniq
           end
 

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -136,5 +136,21 @@ describe Travis::Addons::Handlers::Email do
       config[:email] = { recipients: "#{address}, #{other}", on_success: 'change' }
       expect(handler.recipients).to eql [address, other]
     end
+
+    it 'ignores repo-level unsubscribe' do
+      config[:email] = address
+      Email.create(user: user, email: address)
+      EmailUnsubscribe.create(user: user, repository: repo)
+
+      expect(handler.recipients).to eql [address]
+    end
+
+    it 'observes user-level no emails preference' do
+      config[:email] = address
+      Email.create(user: user, email: address)
+      user.update_attributes!(preferences: JSON.dump(build_emails: false))
+
+      expect(handler.recipients).to be_empty
+    end
   end
 end


### PR DESCRIPTION
From relevant discussion:

> Our assumption that `.travis.yml` wins against settings is wrong in the case of the global user setting because it breaks one current behavior. Even if our code doesn't implement it like that, currently if you unsubscribe using the link in the emails (i.e. directly in mailchimp) you stop getting email even if your email is in `.travis.yml`. We still deliver that email to mailchimp but they don't send it. So if we want to replace mailchimp unsubscribe with our own mechanism, the global setting needs to take precedence over `.travis.yml`

The query that filters the users that have the `build_emails` preference set to false is a bit complex but I _think_ it's fine:

```
=> EXPLAIN for: SELECT "emails".* FROM "emails" INNER JOIN "users" ON "users"."id" = "emails"."user_id" WHERE "emails"."email" = 'me@email.com' AND (preferences->>'build_emails' = 'false')
                                        QUERY PLAN
------------------------------------------------------------------------------------------
 Nested Loop  (cost=4.19..25.72 rows=1 width=56)
   Join Filter: (emails.user_id = users.id)
   ->  Seq Scan on users  (cost=0.00..13.00 rows=1 width=4)
         Filter: ((preferences ->> 'build_emails'::text) = 'false'::text)
   ->  Bitmap Heap Scan on emails  (cost=4.19..12.66 rows=5 width=56)
         Recheck Cond: ((email)::text = 'me@email.com'::text)
         ->  Bitmap Index Scan on index_emails_on_email  (cost=0.00..4.19 rows=5 width=0)
               Index Cond: ((email)::text = 'me@email.com'::text)
```

I used `pry` for debugging this and thought I could add it as part of the PR :man_shrugging: 