### PR TITLE
add delay before indexing via logsearch

### DIFF
--- a/lib/travis/sidekiq.rb
+++ b/lib/travis/sidekiq.rb
@@ -48,7 +48,8 @@ module Travis
       client.push(
         'queue' => ENV['LOGSEARCH_SIDEKIQ_QUEUE'] || 'logsearch',
         'class' => 'Travis::LogSearch::Worker',
-        'args'  => args
+        'args'  => args,
+        'at'    => Time.now.to_f + (ENV['LOGSEARCH_SIDEKIQ_DELAY']&.to_i || 60)
       )
     end
 


### PR DESCRIPTION
There may be a race condition where we are fetching the logs before they get through the log delivery pipeline, resulting in empty or truncated logs.

This extra 60 second delay should hopefully help with that!

Sidekiq scheduling logic borrowed from sidekiq's [lib/sidekiq/worker.rb](https://github.com/mperham/sidekiq/blob/52562b715174e447a0f7666136838521fda69214/lib/sidekiq/worker.rb#L55).

refs https://github.com/travis-ci/reliability/issues/167