### PR TITLE
Pass attributes to addons through sidekiq

### DIFF
--- a/lib/travis/addons/handlers/metrics.rb
+++ b/lib/travis/addons/handlers/metrics.rb
@@ -42,6 +42,7 @@ module Travis
             return unless object.started_at && object.finished_at
             events = %W(job.duration job.duration.#{queue})
             timer(events, object.finished_at - object.started_at)
+            return unless object.received_at
             events = %W(job.total_processing_time job.total_processing_time.#{queue})
             timer(events, object.finished_at - object.received_at)
           end

--- a/lib/travis/event.rb
+++ b/lib/travis/event.rb
@@ -33,7 +33,7 @@ module Travis
     def notify(event, *args)
       prefix = Underscore.new(self.class.name).string
       event  = PastTense.new(event).string
-      Event.dispatch("#{prefix}:#{event}", id: id)
+      Event.dispatch("#{prefix}:#{event}", id: id, attrs: attributes)
     end
   end
 end

--- a/lib/travis/event/handler.rb
+++ b/lib/travis/event/handler.rb
@@ -37,7 +37,11 @@ module Travis
       instrument :notify, on: [:completed, :failed]
 
       def object
-        Kernel.const_get(object_type.camelize).find(params[:id])
+        @object ||= begin
+          obj = Kernel.const_get(object_type.camelize).find(params[:id])
+          obj.assign_attributes(params[:attrs]) if params[:attrs]
+          obj
+        end
       end
 
       private

--- a/lib/travis/hub/helper/locking.rb
+++ b/lib/travis/hub/helper/locking.rb
@@ -7,7 +7,13 @@ module Travis
         def exclusive(key, options = nil, &block)
           options ||= config.lock.to_h
           options[:url] ||= config.redis.url if options[:strategy] == :redis
-          Lock.exclusive(key, options, &block)
+
+          Lock.exclusive(key, options) do
+            logger.debug "Locking #{key}"
+            block.call
+            logger.debug "Releasing #{key}"
+          end
+
         # TODO move this to travis-locks
         rescue Redis::TimeoutError => e
           count ||= 0

--- a/lib/travis/hub/service/update_build.rb
+++ b/lib/travis/hub/service/update_build.rb
@@ -71,16 +71,8 @@ module Travis
             build.jobs.each { |job| NotifyWorkers.new(context).cancel(job) } if event == :cancel
           end
 
-          def lock_key
-            @lock_key ||= "hub:build-#{build.id}"
-          end
-
           def exclusive(&block)
-            super(lock_key, config.lock) do
-              logger.debug "Locking #{lock_key}"
-              block.call
-              logger.debug "Releasing #{lock_key}"
-            end
+            super("hub:build-#{build.id}", config.lock, &block)
           end
 
           def unknown_event

--- a/lib/travis/hub/service/update_job.rb
+++ b/lib/travis/hub/service/update_job.rb
@@ -101,16 +101,8 @@ module Travis
             fail ArgumentError, "Unknown event: #{event.inspect}, data: #{data}"
           end
 
-          def lock_key
-            @lock_key ||= "hub:build-#{job.source_id}"
-          end
-
           def exclusive(&block)
-            super(lock_key, config.lock) do
-              logger.debug "Locking #{lock_key}"
-              block.call
-              logger.debug "Releasing #{lock_key}"
-            end
+            super("hub:build-#{job.source_id}", config.lock, &block)
           end
 
           class Instrument < Instrumentation::Instrument

--- a/spec/travis/hub/model/build_spec.rb
+++ b/spec/travis/hub/model/build_spec.rb
@@ -5,7 +5,7 @@ describe Build do
   let(:build)  { FactoryGirl.create(:build, repository: repo, state: state) }
   let(:job)    { FactoryGirl.create(:job) }
   let(:now)    { Time.now }
-  before       { Travis::Event.stubs(:dispatch) }
+  # before       { Travis::Event.stubs(:dispatch) }
 
   def receive
     build.send(:"#{event}!", params)
@@ -28,7 +28,7 @@ describe Build do
     end
 
     it 'dispatches a build:canceled event' do
-      Travis::Event.expects(:dispatch).with('build:canceled', id: build.id)
+      Travis::Event.expects(:dispatch).with('build:canceled', anything)
       receive
     end
 
@@ -103,7 +103,7 @@ describe Build do
     end
 
     it 'dispatches a build:restarted event' do
-      Travis::Event.expects(:dispatch).with('build:restarted', id: build.id)
+      Travis::Event.expects(:dispatch).with('build:restarted', anything)
       receive
     end
 
@@ -238,7 +238,7 @@ describe Build do
     end
 
     it 'dispatches a build:created event' do
-      Travis::Event.expects(:dispatch).with('build:created', id: build.id)
+      Travis::Event.expects(:dispatch).with('build:created', anything)
       receive
     end
   end

--- a/spec/travis/hub/model/job_spec.rb
+++ b/spec/travis/hub/model/job_spec.rb
@@ -30,7 +30,7 @@ describe Job do
     end
 
     it 'dispatches a job:received event' do
-      Travis::Event.expects(:dispatch).with('job:received', id: job.id)
+      Travis::Event.expects(:dispatch).with('job:received', anything)
       receive
     end
   end
@@ -51,7 +51,7 @@ describe Job do
     end
 
     it 'dispatches a job:started event' do
-      Travis::Event.expects(:dispatch).with('job:started', id: job.id)
+      Travis::Event.expects(:dispatch).with('job:started', anything)
       receive
     end
 
@@ -93,7 +93,7 @@ describe Job do
     end
 
     it 'dispatches a job:finished event' do
-      Travis::Event.expects(:dispatch).with('job:finished', id: job.id)
+      Travis::Event.expects(:dispatch).with('job:finished', anything)
       receive
     end
 
@@ -158,7 +158,7 @@ describe Job do
     end
 
     it 'dispatches a job:canceled event' do
-      Travis::Event.expects(:dispatch).with('job:canceled', id: job.id)
+      Travis::Event.expects(:dispatch).with('job:canceled', anything)
       receive
     end
 
@@ -226,7 +226,7 @@ describe Job do
     end
 
     it 'dispatches a job:restarted event' do
-      Travis::Event.expects(:dispatch).with('job:restarted', id: job.id)
+      Travis::Event.expects(:dispatch).with('job:restarted', anything)
       receive
     end
 

--- a/spec/travis/hub/model/stage_spec.rb
+++ b/spec/travis/hub/model/stage_spec.rb
@@ -30,7 +30,8 @@ describe Stage do
     it { expect(jobs[2].state).to eq :passed }
 
     it { expect(Travis::Event).to have_received(:dispatch).times(4) }
-    it { expect(Travis::Event).to have_received(:dispatch).with('job:finished', id: jobs[0].id) }
+    it { expect(Travis::Event).to have_received(:dispatch).with('job:finished', anything).times(3) }
+    it { expect(Travis::Event).to have_received(:dispatch).with('build:finished', anything).once }
   end
 
   describe 'failure' do

--- a/spec/travis/hub/service/update_build_spec.rb
+++ b/spec/travis/hub/service/update_build_spec.rb
@@ -38,12 +38,12 @@ describe Travis::Hub::Service::UpdateBuild do
     end
 
     it 'dispatches a build:created event' do
-      Travis::Event.expects(:dispatch).with('build:created', id: build.id)
+      Travis::Event.expects(:dispatch).with('build:created', anything)
       subject.run
     end
 
     it 'dispatches job:created events' do
-      Travis::Event.expects(:dispatch).with('job:created', id: job.id)
+      Travis::Event.expects(:dispatch).with('job:created', anything)
       subject.run
     end
 


### PR DESCRIPTION
After moving addon event handling to a Sidekiq queue this does not run as part of the per-build lock anymore, and other events may have modified the respective record in the meantime, so the reloaded model may have unexpected attributes. This passes attributes for builds and jobs through Sidekiq, and re-assigns them before serializing payloads.