### PR TITLE
Debug lock

### DIFF
--- a/lib/travis/hub/config.rb
+++ b/lib/travis/hub/config.rb
@@ -20,7 +20,7 @@ module Travis
              job_board:      { url: 'https://not:set@job-board.travis-ci.com', site: 'org' },
              redis:          { url: ENV['TRAVIS_REDIS_URL'] || 'redis://localhost:6379' },
              sidekiq:        { namespace: 'sidekiq', pool_size: 1 },
-             lock:           { strategy: :redis },
+             lock:           { strategy: :redis, ttl: 30000 },
              states_cache:   { memcached_servers: 'localhost:11211', memcached_options: {} },
              name:           'hub',
              host:           'travis-ci.org',

--- a/lib/travis/hub/helper/locking.rb
+++ b/lib/travis/hub/helper/locking.rb
@@ -7,10 +7,7 @@ module Travis
         def exclusive(key, options = nil, &block)
           options ||= config.lock.to_h
           options[:url] ||= config.redis.url if options[:strategy] == :redis
-
-          debug "Locking #{key} with: #{options[:strategy]}"
           Lock.exclusive(key, options, &block)
-
         # TODO move this to travis-locks
         rescue Redis::TimeoutError => e
           count ||= 0

--- a/lib/travis/hub/service/update_job.rb
+++ b/lib/travis/hub/service/update_job.rb
@@ -101,8 +101,16 @@ module Travis
             fail ArgumentError, "Unknown event: #{event.inspect}, data: #{data}"
           end
 
+          def lock_key
+            @lock_key ||= "hub:build-#{job.source_id}"
+          end
+
           def exclusive(&block)
-            super("hub:build-#{job.source_id}", &block)
+            super(lock_key, config.lock) do
+              logger.debug "Locking #{lock_key}"
+              block.call
+              logger.debug "Releasing #{lock_key}"
+            end
           end
 
           class Instrument < Instrumentation::Instrument


### PR DESCRIPTION
We've been monitoring how travis-lock works in Hub and discovered that its TTL was far too short.

This PR:

1. Sets a default TTL of 30 seconds (which might have to be lowered later);
2. Adds debug lines in the correct place for future monitoring.