### PR TITLE
Send merge notifications only when repo is migrated

### DIFF
--- a/lib/travis/addons/handlers/merge.rb
+++ b/lib/travis/addons/handlers/merge.rb
@@ -9,7 +9,7 @@ module Travis
         EVENTS = /(build|job):(created|received|started|finished|canceled|errored)/
 
         def handle?
-          repository.migrating? || repository.migrated_at
+          repository.migrated_at
         end
 
         def handle

--- a/spec/travis/addons/handlers/merge_spec.rb
+++ b/spec/travis/addons/handlers/merge_spec.rb
@@ -1,5 +1,5 @@
 describe Travis::Addons::Handlers::Merge do
-  let(:repo)    { FactoryGirl.create(:repository, migration_status: 'migrating') }
+  let(:repo)    { FactoryGirl.create(:repository, migration_status: 'migrated', migrated_at: Time.now) }
   let(:job)     { FactoryGirl.create(:job, state: :created, repository: repo) }
   let(:build)   { FactoryGirl.create(:build, state: :created, repository: repo) }
   let(:handler) { described_class.new('build:finished', id: build.id) }


### PR DESCRIPTION
We will run the full history import anyway, so it's fine to send updates
only when the repo finished updating. Sending build updates sooner than
that may be problematic because we might not necessarily have all the
data in the com database.