### PR TITLE
Allow notifications of the same type

### DIFF
--- a/lib/travis/addons/config.rb
+++ b/lib/travis/addons/config.rb
@@ -17,24 +17,43 @@ module Travis
       end
 
       def enabled?(key)
-        return false unless notifications.respond_to?(:has_key?)
-        return !!notifications[key] if notifications.has_key?(key) # TODO this seems inconsistent. what if email: { disabled: true }
-        [:disabled, :disable].each { |key| return !notifications[key] if notifications.has_key?(key) } # TODO deprecate disabled and disable
-        true
+        notifications.any? do |notifier|
+          if !notifier.respond_to?(:has_key?)
+            false
+          elsif notifier.has_key?(key)
+            !!notifier[key]
+          elsif notifier.has_key?(:disabled)
+            !notifier[:disabled]
+          elsif notifier.has_key?(:disable)
+            !notifier[:disable]
+          else
+            true
+          end
+        end
       end
 
       def send_on?(type, event)
-        Notify.new(build, notifications).on?(type, event)
+        notifications.any? do |notifier|
+          Notify.new(build, notifier).on?(type, event)
+        end
       end
 
       def values(type, key)
-        config = notifications[type] rescue {}
-        value  = config.is_a?(Hash) ? config[key] : config
-        value.is_a?(Array) || value.is_a?(String) ? normalize_array(value) : value
+        notifications.map do |notifier|
+          config = notifier[type] rescue {}
+          value  = config.is_a?(Hash) ? config[key] : config
+          value.is_a?(Array) || value.is_a?(String) ? normalize_array(value) : value
+        end
       end
 
       def notifications
-        @notifications ||= Travis::SecureConfig.decrypt(config.fetch(:notifications, {}) || {}, secure_key)
+        return @notifications if @notifications
+        decrypted = Travis::SecureConfig.decrypt(config.fetch(:notifications, {}) || {}, secure_key)
+        if decrypted.is_a? Hash
+          @notifications = [decrypted]
+        else
+          @notifications = Array(decrypted)
+        end
       end
 
       private

--- a/lib/travis/addons/handlers/base.rb
+++ b/lib/travis/addons/handlers/base.rb
@@ -37,7 +37,7 @@ module Travis
         end
 
         def on_pull_request?(sym)
-          value = config.values(sym, :on_pull_requests)
+          value = config.values(sym, :on_pull_requests).any?
           value.nil? || value
         end
       end

--- a/lib/travis/addons/handlers/campfire.rb
+++ b/lib/travis/addons/handlers/campfire.rb
@@ -10,11 +10,13 @@ module Travis
         EVENTS = 'build:finished'
 
         def handle?
-          !pull_request? && targets.present? && config.send_on?(:campfire, action)
+          !pull_request? && targets.any?(&:present?) && config.send_on?(:campfire, action)
         end
 
         def handle
-          run_task(:campfire, payload, targets: targets)
+          targets.each do |target|
+            run_task(:campfire, payload, targets: target)
+          end
         end
 
         def targets

--- a/lib/travis/addons/handlers/email.rb
+++ b/lib/travis/addons/handlers/email.rb
@@ -21,10 +21,8 @@ module Travis
         end
 
         def recipients(cfg)
-          @recipients ||= begin
-            emails = configured_emails(cfg) || default_emails(cfg)
-            emails - ::Email.joins(:user).where(email: emails).merge(User.with_preference(:build_emails, false)).pluck(:email).uniq
-          end
+          emails = configured_emails(cfg) || default_emails(cfg)
+          emails - ::Email.joins(:user).where(email: emails).merge(User.with_preference(:build_emails, false)).pluck(:email).uniq
         end
 
         private

--- a/lib/travis/addons/handlers/flowdock.rb
+++ b/lib/travis/addons/handlers/flowdock.rb
@@ -10,11 +10,13 @@ module Travis
         EVENTS = 'build:finished'
 
         def handle?
-          !pull_request? && targets.present? && config.send_on?(:flowdock, action)
+          !pull_request? && targets.any?(&:present?) && config.send_on?(:flowdock, action)
         end
 
         def handle
-          run_task(:flowdock, payload, targets: targets)
+          targets.each do |target|
+            run_task(:flowdock, payload, targets: target)
+          end
         end
 
         def targets
@@ -31,4 +33,3 @@ module Travis
     end
   end
 end
-

--- a/lib/travis/addons/handlers/hipchat.rb
+++ b/lib/travis/addons/handlers/hipchat.rb
@@ -10,11 +10,13 @@ module Travis
         EVENTS = 'build:finished'
 
         def handle?
-          enabled?(:hipchat) && targets.present? && config.send_on?(:hipchat, action)
+          enabled?(:hipchat) && targets.any?(&:present?) && config.send_on?(:hipchat, action)
         end
 
         def handle
-          run_task(:hipchat, payload, targets: targets)
+          targets.each do |target|
+            run_task(:hipchat, payload, targets: target)
+          end
         end
 
         def targets

--- a/lib/travis/addons/handlers/irc.rb
+++ b/lib/travis/addons/handlers/irc.rb
@@ -10,11 +10,13 @@ module Travis
         EVENTS = 'build:finished'
 
         def handle?
-          !pull_request? && channels.present? && config.send_on?(:irc, action)
+          !pull_request? && channels.any?(&:present?) && config.send_on?(:irc, action)
         end
 
         def handle
-          run_task(:irc, payload, channels: channels)
+          channels.each do |ch|
+            run_task(:irc, payload, channels: ch)
+          end
         end
 
         def channels
@@ -31,4 +33,3 @@ module Travis
     end
   end
 end
-

--- a/lib/travis/addons/handlers/slack.rb
+++ b/lib/travis/addons/handlers/slack.rb
@@ -25,7 +25,9 @@ module Travis
 
         class Instrument < Addons::Instrument
           def notify_completed
-            publish(targets: handler.targets)
+            handler.targets.each do |target|
+              publish(targets: target)
+            end
           end
         end
         Instrument.attach_to(self)

--- a/lib/travis/addons/handlers/slack.rb
+++ b/lib/travis/addons/handlers/slack.rb
@@ -10,11 +10,13 @@ module Travis
         EVENTS = 'build:finished'
 
         def handle?
-          enabled?(:slack) && targets.present? && config.send_on?(:slack, action)
+          enabled?(:slack) && targets.any?(&:present?) && config.send_on?(:slack, action)
         end
 
         def handle
-          run_task(:slack, payload, targets: targets)
+          targets.each do |target|
+            run_task(:slack, payload, targets: target)
+          end
         end
 
         def targets
@@ -31,4 +33,3 @@ module Travis
     end
   end
 end
-

--- a/lib/travis/addons/handlers/webhook.rb
+++ b/lib/travis/addons/handlers/webhook.rb
@@ -10,11 +10,13 @@ module Travis
         EVENTS = /build:(started|finished|canceled|errored)/
 
         def handle?
-          targets.present? && config.send_on?(:webhooks, action)
+          targets.any?(&:present?) && config.send_on?(:webhooks, action)
         end
 
         def handle
-          run_task(:webhook, payload, targets: targets, token: request.token)
+          targets.each do |target|
+            run_task(:webhook, payload, targets: target, token: request.token)
+          end
         end
 
         def targets

--- a/spec/travis/addons/handlers/campfire_spec.rb
+++ b/spec/travis/addons/handlers/campfire_spec.rb
@@ -62,32 +62,32 @@ describe Travis::Addons::Handlers::Campfire do
 
     it 'returns an array of rooms when given a string' do
       config[:campfire] = room
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms when given an array' do
       config[:campfire] = [room]
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms when given a comma separated string' do
       config[:campfire] = "#{room}, #{other}"
-      expect(handler.targets).to eql [room, other]
+      expect(handler.targets).to eql [[room, other]]
     end
 
     it 'returns an array of rooms given a string within a hash' do
       config[:campfire] = { rooms: room, on_success: 'change' }
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms given an array within a hash' do
       config[:campfire] = { rooms: [room], on_success: 'change' }
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms given a comma separated string within a hash' do
       config[:campfire] = { rooms: "#{room}, #{other}", on_success: 'change' }
-      expect(handler.targets).to eql [room, other]
+      expect(handler.targets).to eql [[room, other]]
     end
   end
 end

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -66,6 +66,21 @@ describe Travis::Addons::Handlers::Email do
       handler.expects(:run_task).with(:email, is_a(Hash), recipients: [recipient], broadcasts: [{ message: 'message', category: 'announcement'}])
       handler.handle
     end
+
+    context "when 2 email notifications are configured" do
+      let(:config) {
+        [
+          {email: address},
+          {email: ["joe@example.com"]},
+        ]
+      }
+
+      it 'enqueues 2 distinct email tasks' do
+        handler.expects(:run_task).with(:email, is_a(Hash), recipients: [address], broadcasts: [{ message: 'message', category: 'announcement'}])
+        handler.expects(:run_task).with(:email, is_a(Hash), recipients: ["joe@example.com"], broadcasts: [{ message: 'message', category: 'announcement'}])
+        handler.handle
+      end
+    end
   end
 
   describe 'recipients' do

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -81,60 +81,60 @@ describe Travis::Addons::Handlers::Email do
 
       it 'returns permitted and known committer and author addresses' do
         [committer, author].each { |address| Email.create(user: user, email: address) }
-        expect(handler.recipients.sort).to eql [author, committer]
+        expect(handler.recipients(config).sort).to eql [author, committer]
       end
 
       it 'returns permitted and known author address' do
         Email.create(user: user, email: author)
-        expect(handler.recipients).to eql [author]
+        expect(handler.recipients(config)).to eql [author]
       end
 
       it 'returns permitted and known committer address' do
         Email.create(user: user, email: committer)
-        expect(handler.recipients).to eql [committer]
+        expect(handler.recipients(config)).to eql [committer]
       end
 
       it 'does not return users who have unsubscribed from this repo' do
         Email.create(user: user, email: committer)
         EmailUnsubscribe.create(user: user, repository: repo)
-        expect(handler.recipients).to be_empty
+        expect(handler.recipients(config)).to be_empty
       end
 
       it 'does not return users who have the no emails global preference' do
         user.update_attributes!(preferences: JSON.dump(build_emails: false))
         Email.create(user: user, email: committer)
-        expect(handler.recipients).to be_empty
+        expect(handler.recipients(config)).to be_empty
       end
     end
 
     it 'returns an array of addresses when given a string' do
       config[:email] = address
-      expect(handler.recipients).to eql [address]
+      expect(handler.recipients(config)).to eql [address]
     end
 
     it 'returns an array of addresses when given an array' do
       config[:email] = [address]
-      expect(handler.recipients).to eql [address]
+      expect(handler.recipients(config)).to eql [address]
     end
 
     it 'returns an array of addresses when given a comma separated string' do
       config[:email] = "#{address}, #{other}"
-      expect(handler.recipients).to eql [address, other]
+      expect(handler.recipients(config)).to eql [address, other]
     end
 
     it 'returns an array of addresses given a string within a hash' do
       config[:email] = { recipients: address, on_success: 'change' }
-      expect(handler.recipients).to eql [address]
+      expect(handler.recipients(config)).to eql [address]
     end
 
     it 'returns an array of addresses given an array within a hash' do
       config[:email] = { recipients: [address], on_success: 'change' }
-      expect(handler.recipients).to eql [address]
+      expect(handler.recipients(config)).to eql [address]
     end
 
     it 'returns an array of addresses given a comma separated string within a hash' do
       config[:email] = { recipients: "#{address}, #{other}", on_success: 'change' }
-      expect(handler.recipients).to eql [address, other]
+      expect(handler.recipients(config)).to eql [address, other]
     end
 
     it 'ignores repo-level unsubscribe' do
@@ -142,7 +142,7 @@ describe Travis::Addons::Handlers::Email do
       Email.create(user: user, email: address)
       EmailUnsubscribe.create(user: user, repository: repo)
 
-      expect(handler.recipients).to eql [address]
+      expect(handler.recipients(config)).to eql [address]
     end
 
     it 'observes user-level no emails preference' do
@@ -150,7 +150,7 @@ describe Travis::Addons::Handlers::Email do
       Email.create(user: user, email: address)
       user.update_attributes!(preferences: JSON.dump(build_emails: false))
 
-      expect(handler.recipients).to be_empty
+      expect(handler.recipients(config)).to be_empty
     end
   end
 end

--- a/spec/travis/addons/handlers/flowdock_spec.rb
+++ b/spec/travis/addons/handlers/flowdock_spec.rb
@@ -62,32 +62,32 @@ describe Travis::Addons::Handlers::Flowdock do
 
     it 'returns an array of rooms when given a string' do
       config[:flowdock] = room
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms when given an array' do
       config[:flowdock] = [room]
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms when given a comma separated string' do
       config[:flowdock] = "#{room}, #{other}"
-      expect(handler.targets).to eql [room, other]
+      expect(handler.targets).to eql [[room, other]]
     end
 
     it 'returns an array of rooms given a string within a hash' do
       config[:flowdock] = { rooms: room, on_success: 'change' }
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms given an array within a hash' do
       config[:flowdock] = { rooms: [room], on_success: 'change' }
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms given a comma separated string within a hash' do
       config[:flowdock] = { rooms: "#{room}, #{other}", on_success: 'change' }
-      expect(handler.targets).to eql [room, other]
+      expect(handler.targets).to eql [[room, other]]
     end
   end
 end

--- a/spec/travis/addons/handlers/hipchat_spec.rb
+++ b/spec/travis/addons/handlers/hipchat_spec.rb
@@ -68,32 +68,32 @@ describe Travis::Addons::Handlers::Hipchat do
 
     it 'returns an array of rooms when given a string' do
       config[:hipchat] = room
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms when given an array' do
       config[:hipchat] = [room]
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms when given a comma separated string' do
       config[:hipchat] = "#{room}, #{other}"
-      expect(handler.targets).to eql [room, other]
+      expect(handler.targets).to eql [[room, other]]
     end
 
     it 'returns an array of rooms given a string within a hash' do
       config[:hipchat] = { rooms: room, on_success: 'change' }
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms given an array within a hash' do
       config[:hipchat] = { rooms: [room], on_success: 'change' }
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms given a comma separated string within a hash' do
       config[:hipchat] = { rooms: "#{room}, #{other}", on_success: 'change' }
-      expect(handler.targets).to eql [room, other]
+      expect(handler.targets).to eql [[room, other]]
     end
   end
 end

--- a/spec/travis/addons/handlers/irc_spec.rb
+++ b/spec/travis/addons/handlers/irc_spec.rb
@@ -62,32 +62,32 @@ describe Travis::Addons::Handlers::Irc do
 
     it 'returns an array of channels when given a string' do
       config[:irc] = channel
-      expect(handler.channels).to eql [channel]
+      expect(handler.channels).to eql [[channel]]
     end
 
     it 'returns an array of channels when given an array' do
       config[:irc] = [channel]
-      expect(handler.channels).to eql [channel]
+      expect(handler.channels).to eql [[channel]]
     end
 
     it 'returns an array of channels when given a comma separated string' do
       config[:irc] = "#{channel}, #{other}"
-      expect(handler.channels).to eql [channel, other]
+      expect(handler.channels).to eql [[channel, other]]
     end
 
     it 'returns an array of channels given a string within a hash' do
       config[:irc] = { channels: channel, on_success: 'change' }
-      expect(handler.channels).to eql [channel]
+      expect(handler.channels).to eql [[channel]]
     end
 
     it 'returns an array of channels given an array within a hash' do
       config[:irc] = { channels: [channel], on_success: 'change' }
-      expect(handler.channels).to eql [channel]
+      expect(handler.channels).to eql [[channel]]
     end
 
     it 'returns an array of channels given a comma separated string within a hash' do
       config[:irc] = { channels: "#{channel}, #{other}", on_success: 'change' }
-      expect(handler.channels).to eql [channel, other]
+      expect(handler.channels).to eql [[channel, other]]
     end
   end
 end

--- a/spec/travis/addons/handlers/pushover_spec.rb
+++ b/spec/travis/addons/handlers/pushover_spec.rb
@@ -62,17 +62,17 @@ describe Travis::Addons::Handlers::Pushover do
 
     it 'returns an array of users when given a string' do
       config[:pushover][:users] = user
-      expect(handler.users).to eql [user]
+      expect(handler.users(config)).to eql [user]
     end
 
     it 'returns an array of user when given an array' do
       config[:pushover][:users] = [user]
-      expect(handler.users).to eql [user]
+      expect(handler.users(config)).to eql [user]
     end
 
     it 'returns an array of user when given a comma separated string' do
       config[:pushover][:users] = "#{user}, #{other}"
-      expect(handler.users).to eql [user, other]
+      expect(handler.users(config)).to eql [user, other]
     end
   end
 end

--- a/spec/travis/addons/handlers/slack_spec.rb
+++ b/spec/travis/addons/handlers/slack_spec.rb
@@ -60,6 +60,21 @@ describe Travis::Addons::Handlers::Slack do
       handler.expects(:run_task).with(:slack, is_a(Hash), targets: ['room'])
       handler.handle
     end
+
+    context 'when multiple notifications are defined' do
+      let(:config) {
+        [
+          { slack: 'room' },
+          { slack: 'room2' }
+        ]
+      }
+
+      it 'enqueues multiple tasks' do
+        handler.expects(:run_task).with(:slack, is_a(Hash), targets: ['room'])
+        handler.expects(:run_task).with(:slack, is_a(Hash), targets: ['room2'])
+        handler.handle
+      end
+    end
   end
 
   describe 'targets' do

--- a/spec/travis/addons/handlers/slack_spec.rb
+++ b/spec/travis/addons/handlers/slack_spec.rb
@@ -68,32 +68,32 @@ describe Travis::Addons::Handlers::Slack do
 
     it 'returns an array of rooms when given a string' do
       config[:slack] = room
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms when given an array' do
       config[:slack] = [room]
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms when given a comma separated string' do
       config[:slack] = "#{room}, #{other}"
-      expect(handler.targets).to eql [room, other]
+      expect(handler.targets).to eql [[room, other]]
     end
 
     it 'returns an array of rooms given a string within a hash' do
       config[:slack] = { rooms: room, on_success: 'change' }
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms given an array within a hash' do
       config[:slack] = { rooms: [room], on_success: 'change' }
-      expect(handler.targets).to eql [room]
+      expect(handler.targets).to eql [[room]]
     end
 
     it 'returns an array of rooms given a comma separated string within a hash' do
       config[:slack] = { rooms: "#{room}, #{other}", on_success: 'change' }
-      expect(handler.targets).to eql [room, other]
+      expect(handler.targets).to eql [[room, other]]
     end
   end
 end

--- a/spec/travis/addons/handlers/webhook_spec.rb
+++ b/spec/travis/addons/handlers/webhook_spec.rb
@@ -65,42 +65,42 @@ describe Travis::Addons::Handlers::Webhook do
 
     it 'returns an array of targets when given a string' do
       config[:webhooks] = target
-      expect(handler.targets).to eql [target]
+      expect(handler.targets).to eql [[target]]
     end
 
     it 'returns an array of targets when given an array' do
       config[:webhooks] = [target]
-      expect(handler.targets).to eql [target]
+      expect(handler.targets).to eql [[target]]
     end
 
     it 'returns an array of targets when given a comma separated string' do
       config[:webhooks] = "#{target}, #{other}"
-      expect(handler.targets).to eql [target, other]
+      expect(handler.targets).to eql [[target, other]]
     end
 
     it 'returns an array of targets given a string within a hash' do
       config[:webhooks] = { urls: target, on_success: 'change' }
-      expect(handler.targets).to eql [target]
+      expect(handler.targets).to eql [[target]]
     end
 
     it 'returns an array of targets given an array within a hash' do
       config[:webhooks] = { urls: [target], on_success: 'change' }
-      expect(handler.targets).to eql [target]
+      expect(handler.targets).to eql [[target]]
     end
 
     it 'returns an array of targets given a comma separated string within a hash' do
       config[:webhooks] = { urls: "#{target}, #{other}", on_success: 'change' }
-      expect(handler.targets).to eql [target, other]
+      expect(handler.targets).to eql [[target, other]]
     end
 
     it 'returns an array of targets given a string within a hash on_cancel' do
       config[:webhooks] = { urls: target, on_cancel: 'change' }
-      expect(handler.targets).to eql [target]
+      expect(handler.targets).to eql [[target]]
     end
 
     it 'returns an array of targets given a string within a hash on_errored' do
       config[:webhooks] = { urls: target, on_error: 'change' }
-      expect(handler.targets).to eql [target]
+      expect(handler.targets).to eql [[target]]
     end
   end
 end


### PR DESCRIPTION
This PR resolves https://github.com/travis-ci/travis-ci/issues/4106

Currently, the following notification configuration is silently ignored:

```yaml
notifications:
  - slack: "foobar"
      on_success: change
  - slack: "barbaz"
      on_success: always
```

This PR aims to handle such configurations gracefully.