### PR TITLE
Use Postgres 9.6 via build config branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 
 import:
-  - travis-ci/build-configs:db-setup.yml
+  - travis-ci/build-configs:db-setup.yml@postgres-9.6
 
 rvm: 2.4.2
 


### PR DESCRIPTION
We updated the shared build config to use Postgres 11, but unfortunately this isn't currently compatible with the trusty build image. Upgrading to xenial was also unsuccessful due to an issue with rabbitmq, so restoring the old behavior to unblock us.