### PR TITLE
fix ruby executable error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ ARG bundle_gems__contribsys__com
 RUN bundle config https://gems.contribsys.com/ $bundle_gems__contribsys__com \
       && bundle install --deployment \
       && bundle config --delete https://gems.contribsys.com/
+RUN gem install --user-install executable-hooks
 
 COPY . /app


### PR DESCRIPTION
Objective:
- fix 
```
warning: pgbouncer buildpack not found, setting PGBOUNCER_ENABLED=false
port=3000 rack_env=production web_concurrency=4 nginx_workers=4
/usr/bin/env: 'ruby_executable_hooks': No such file or directory
```
