### PR TITLE
Send manual build cancelation emails

### DIFF
--- a/lib/travis/addons/handlers/email.rb
+++ b/lib/travis/addons/handlers/email.rb
@@ -6,12 +6,12 @@ module Travis
   module Addons
     module Handlers
       class Email < Notifiers
-        EVENTS = 'build:finished'
+        EVENTS = /build:(finished|canceled)/
         KEY = :email
 
         class Notifier < Notifier
           def handle?
-            !pull_request? && config.enabled? && config.send_on?(:email, action) && recipients.present?
+            !pull_request? && config.enabled? && config.send_on?(:email, action) && recipients.present? && !config[:auto_canceled?]
           end
 
           def handle

--- a/lib/travis/addons/handlers/notifier.rb
+++ b/lib/travis/addons/handlers/notifier.rb
@@ -60,7 +60,20 @@ module Travis
         end
 
         def config
-          @config ||= Config.new(object, params[:config])
+          @config ||= begin
+            params[:config][:auto_canceled?] = true if auto_canceled?
+            Config.new(object, params[:config])
+          end
+        end
+
+        private
+
+        def meta
+          @meta ||= (params[:meta] || {}).symbolize_keys
+        end
+
+        def auto_canceled?
+          !!meta[:auto]
         end
       end
     end

--- a/spec/travis/addons/handlers/email_spec.rb
+++ b/spec/travis/addons/handlers/email_spec.rb
@@ -33,6 +33,26 @@ describe Travis::Addons::Handlers::Email do
   end
 
   describe 'handle?' do
+    context "when auto-canceling build" do
+      let(:config) { { recipients: 'one@email.com', auto_canceled?: true } }
+      let(:handler) { described_class::Notifier.new('build:canceled', id: build.id, config: config) }
+
+      it 'is false if the build is auto-canceled' do
+        build.update_attributes(event_type: 'push', state: 'canceled')
+        expect(handler.handle?).to eql(false)
+      end
+    end
+
+    context "when manually canceling build" do
+      let(:config) { { recipients: 'one@email.com', auto_canceled?: false } }
+      let(:handler) { described_class::Notifier.new('build:canceled', id: build.id, config: config) }
+
+      it 'is true' do
+        build.update_attributes(event_type: 'push', state: 'canceled')
+        expect(handler.handle?).to eql(true)
+      end
+    end
+
     it 'is true if the build is a push request' do
       build.update_attributes(event_type: 'push')
       expect(handler.handle?).to eql(true)


### PR DESCRIPTION
Auto-cancelation would cause a tremendous amount of noise for larger repositories, so we check the event metadata from Gator and set it as part of the config. Inside the email handler, we can then check if the build has been auto-canceled or not, only handling the event if it was canceled manually.