### PR TITLE
Fast track feature going live

### DIFF
--- a/lib/travis/hub/service/update_build.rb
+++ b/lib/travis/hub/service/update_build.rb
@@ -16,6 +16,7 @@ module Travis
           canceled:     %(This job was cancelled because the "Auto Cancellation" feature is currently enabled, and a more recent build (#%{number}) for %{info} came in while this job was waiting to be processed.\n\n),
           push:         'branch %{branch}',
           pull_request: 'pull request #%{pull_request_number}',
+          api:          'This job was cancelled due to other priority builds'
         }
 
         def run

--- a/spec/travis/hub/service/update_build_spec.rb
+++ b/spec/travis/hub/service/update_build_spec.rb
@@ -178,6 +178,25 @@ describe Travis::Hub::Service::UpdateBuild do
     end
   end
 
+  # cancel jobs from custom build request, ie: event: :api
+  describe 'cancel event (gator, api cancel)' do
+    let(:state) { :created }
+    let(:event) { :cancel }
+    let(:meta)  { { 'auto' => true, 'event' => 'api', 'number' => '2', 'branch' => 'master', 'pull_request_number' => nil } }
+    let(:data)  { { id: build.id, meta: meta } }
+    let(:now) { Time.now }
+
+    before do
+      subject.send(:logs_api).expects(:append_log_part)
+    end
+
+    it 'updates the job' do
+      subject.run
+      expect(job.reload.state).to eql(:canceled)
+      expect(job.reload.canceled_at).to eql(now)
+    end
+  end
+
   describe 'restart event' do
     let(:state) { :passed }
     let(:event) { :restart }


### PR DESCRIPTION
Custom builds created via the UI will be cancelled when the priority cancel build keyword will be used.